### PR TITLE
Selection fix

### DIFF
--- a/src/components/DiagramCanvas.tsx
+++ b/src/components/DiagramCanvas.tsx
@@ -286,7 +286,7 @@ function FlowCanvas() {
                 const selectedEdgeIds =
                     useStore.getState().selectedElements.edges;
 
-                // Comment out the automatic edge selection
+                // Might need this later on
                 /* 
                 const connectedEdges = edges.filter(
                     (edge) =>

--- a/src/components/DiagramCanvas.tsx
+++ b/src/components/DiagramCanvas.tsx
@@ -286,6 +286,8 @@ function FlowCanvas() {
                 const selectedEdgeIds =
                     useStore.getState().selectedElements.edges;
 
+                // Comment out the automatic edge selection
+                /* 
                 const connectedEdges = edges.filter(
                     (edge) =>
                         selectedNodeIds.includes(edge.source) ||
@@ -308,6 +310,7 @@ function FlowCanvas() {
                         );
                     });
                 }
+                */
 
                 const DRAG_PROXY_THRESHOLD = 3;
                 const selectedNodes = nodes.filter((node) =>


### PR DESCRIPTION
This pull request includes a minor change in the `FlowCanvas` function within the `src/components/DiagramCanvas.tsx` file. The change comments out a block of code that filters edges connected to selected nodes, with a note indicating it might be needed in the future.

Code commenting:

* Commented out the `connectedEdges` filtering logic in the `FlowCanvas` function, potentially for future use. [[1]](diffhunk://#diff-cfe4b1c13f04ba4300eededdc74ec19e02718dd73c793e4e52b0ce7e4e1f0c2dR289-R290) [[2]](diffhunk://#diff-cfe4b1c13f04ba4300eededdc74ec19e02718dd73c793e4e52b0ce7e4e1f0c2dR313)