### PR TITLE
Add RCQ edge

### DIFF
--- a/src/components/edges/activitybased/resourceconstrained/RCQEdge.tsx
+++ b/src/components/edges/activitybased/resourceconstrained/RCQEdge.tsx
@@ -1,0 +1,733 @@
+"use client";
+
+import React, {
+    memo,
+    useState,
+    useCallback,
+    MouseEvent,
+    useRef,
+    useEffect,
+} from "react";
+import {
+    EdgeProps,
+    BaseEdge,
+    EdgeLabelRenderer,
+    getStraightPath,
+    getBezierPath,
+    getSmoothStepPath,
+    Position,
+} from "reactflow";
+import { MathJax } from "better-react-mathjax";
+import { CommandController } from "@/controllers/CommandController";
+import {
+    parseTransformMatrix,
+    clientToFlowPosition,
+    throttle,
+    snapToGrid,
+} from "@/lib/utils/math";
+import { calculateDefaultControlPoints } from "@/lib/utils/edge";
+
+const commandController = CommandController.getInstance();
+
+type EdgeTypeOption = "straight" | "bezier" | "smoothstep";
+
+interface RCQEdgeData {
+    edgeType?: EdgeTypeOption;
+    controlPoint1?: { x: number; y: number };
+    controlPoint2?: { x: number; y: number };
+    controlPoint3?: { x: number; y: number };
+    condition?: string;
+    conditionLabelOffset?: { x: number; y: number };
+}
+
+interface ExtendedEdgeProps extends EdgeProps<RCQEdgeData> {
+    onClick?: () => void;
+}
+
+interface RCQEdgeComponent
+    extends React.NamedExoticComponent<ExtendedEdgeProps> {
+    getDefaultData?: () => RCQEdgeData;
+    getGraphType?: () => string;
+    displayName?: string;
+}
+
+const RCQEdge = memo(
+    ({
+        id,
+        sourceX,
+        sourceY,
+        targetX,
+        targetY,
+        sourcePosition,
+        targetPosition,
+        style = {},
+        data = {} as RCQEdgeData,
+        markerEnd,
+        selected,
+        onClick,
+    }: ExtendedEdgeProps) => {
+        const [isDragging, setIsDragging] = useState<number | null>(null);
+        const [isConditionDragging, setIsConditionDragging] = useState(false);
+        const [tempControlPoints, setTempControlPoints] = useState<{
+            cp1?: { x: number; y: number };
+            cp2?: { x: number; y: number };
+            cp3?: { x: number; y: number };
+        }>({});
+        const [tempConditionPosition, setTempConditionPosition] = useState<{
+            x: number;
+            y: number;
+        } | null>(null);
+
+        const flowPaneRef = useRef<Element | null>(null);
+        const transformMatrixRef = useRef<ReturnType<
+            typeof parseTransformMatrix
+        > | null>(null);
+        const dragOffsetRef = useRef<{ x: number; y: number } | null>(null);
+
+        const edgeStyle = {
+            strokeWidth: selected ? 3 : 2,
+            stroke: selected ? "#3b82f6" : "#555",
+            ...style,
+        };
+
+        const edgeType = data?.edgeType || "straight";
+
+        const defaultControlPoints = calculateDefaultControlPoints(
+            sourceX,
+            sourceY,
+            targetX,
+            targetY
+        );
+
+        const controlPoint1 =
+            isDragging === 1 && tempControlPoints.cp1
+                ? tempControlPoints.cp1
+                : data?.controlPoint1 || defaultControlPoints.cp1;
+
+        const controlPoint2 =
+            isDragging === 2 && tempControlPoints.cp2
+                ? tempControlPoints.cp2
+                : data?.controlPoint2 || defaultControlPoints.cp2;
+
+        const controlPoint3 =
+            isDragging === 3 && tempControlPoints.cp3
+                ? tempControlPoints.cp3
+                : data?.controlPoint3 || defaultControlPoints.cp3;
+
+        let edgePath: string;
+        let labelX: number, labelY: number;
+        let conditionMarkerX: number, conditionMarkerY: number;
+        let conditionMarkerAngle: number;
+
+        labelX = controlPoint2.x;
+        labelY = controlPoint2.y;
+
+        conditionMarkerX = controlPoint2.x;
+        conditionMarkerY = controlPoint2.y;
+
+        if (edgeType === "straight") {
+            conditionMarkerAngle =
+                Math.atan2(
+                    controlPoint3.y - controlPoint1.y,
+                    controlPoint3.x - controlPoint1.x
+                ) *
+                (180 / Math.PI);
+        } else {
+            conditionMarkerAngle =
+                Math.atan2(targetY - sourceY, targetX - sourceX) *
+                (180 / Math.PI);
+        }
+
+        const hasCondition =
+            data?.condition &&
+            data.condition.trim() !== "" &&
+            data.condition !== "True";
+        const showConditionMarker = hasCondition;
+
+        const defaultConditionLabelOffset = { x: 0, y: -30 };
+        const conditionLabelOffset =
+            isConditionDragging && tempConditionPosition
+                ? {
+                      x: tempConditionPosition.x - conditionMarkerX,
+                      y: tempConditionPosition.y - conditionMarkerY,
+                  }
+                : data?.conditionLabelOffset || defaultConditionLabelOffset;
+
+        const conditionLabelX = conditionMarkerX + conditionLabelOffset.x;
+        const conditionLabelY = conditionMarkerY + conditionLabelOffset.y;
+
+        switch (edgeType) {
+            case "bezier":
+                const [segment1] = getBezierPath({
+                    sourceX,
+                    sourceY,
+                    sourcePosition: Position.Right,
+                    targetX: controlPoint1.x,
+                    targetY: controlPoint1.y,
+                    targetPosition: Position.Left,
+                });
+                const [segment2] = getBezierPath({
+                    sourceX: controlPoint1.x,
+                    sourceY: controlPoint1.y,
+                    sourcePosition: Position.Right,
+                    targetX: controlPoint2.x,
+                    targetY: controlPoint2.y,
+                    targetPosition: Position.Left,
+                });
+                const [segment3] = getBezierPath({
+                    sourceX: controlPoint2.x,
+                    sourceY: controlPoint2.y,
+                    sourcePosition: Position.Right,
+                    targetX: controlPoint3.x,
+                    targetY: controlPoint3.y,
+                    targetPosition: Position.Left,
+                });
+                const [segment4] = getBezierPath({
+                    sourceX: controlPoint3.x,
+                    sourceY: controlPoint3.y,
+                    sourcePosition: Position.Right,
+                    targetX,
+                    targetY,
+                    targetPosition: Position.Left,
+                });
+
+                edgePath =
+                    segment1 +
+                    " " +
+                    segment2.replace("M", "L") +
+                    " " +
+                    segment3.replace("M", "L") +
+                    " " +
+                    segment4.replace("M", "L");
+                break;
+
+            case "smoothstep":
+                const [smoothSegment1] = getSmoothStepPath({
+                    sourceX,
+                    sourceY,
+                    sourcePosition: Position.Right,
+                    targetX: controlPoint1.x,
+                    targetY: controlPoint1.y,
+                    targetPosition: Position.Left,
+                });
+                const [smoothSegment2] = getSmoothStepPath({
+                    sourceX: controlPoint1.x,
+                    sourceY: controlPoint1.y,
+                    sourcePosition: Position.Right,
+                    targetX: controlPoint2.x,
+                    targetY: controlPoint2.y,
+                    targetPosition: Position.Left,
+                });
+                const [smoothSegment3] = getSmoothStepPath({
+                    sourceX: controlPoint2.x,
+                    sourceY: controlPoint2.y,
+                    sourcePosition: Position.Right,
+                    targetX: controlPoint3.x,
+                    targetY: controlPoint3.y,
+                    targetPosition: Position.Left,
+                });
+                const [smoothSegment4] = getSmoothStepPath({
+                    sourceX: controlPoint3.x,
+                    sourceY: controlPoint3.y,
+                    sourcePosition: Position.Right,
+                    targetX,
+                    targetY,
+                    targetPosition: Position.Left,
+                });
+
+                edgePath =
+                    smoothSegment1 +
+                    " " +
+                    smoothSegment2.replace("M", "L") +
+                    " " +
+                    smoothSegment3.replace("M", "L") +
+                    " " +
+                    smoothSegment4.replace("M", "L");
+                break;
+
+            case "straight":
+            default:
+                const [straightSegment1] = getStraightPath({
+                    sourceX,
+                    sourceY,
+                    targetX: controlPoint1.x,
+                    targetY: controlPoint1.y,
+                });
+                const [straightSegment2] = getStraightPath({
+                    sourceX: controlPoint1.x,
+                    sourceY: controlPoint1.y,
+                    targetX: controlPoint2.x,
+                    targetY: controlPoint2.y,
+                });
+                const [straightSegment3] = getStraightPath({
+                    sourceX: controlPoint2.x,
+                    sourceY: controlPoint2.y,
+                    targetX: controlPoint3.x,
+                    targetY: controlPoint3.y,
+                });
+                const [straightSegment4] = getStraightPath({
+                    sourceX: controlPoint3.x,
+                    sourceY: controlPoint3.y,
+                    targetX,
+                    targetY,
+                });
+
+                edgePath =
+                    straightSegment1 +
+                    " " +
+                    straightSegment2.replace("M", "L") +
+                    " " +
+                    straightSegment3.replace("M", "L") +
+                    " " +
+                    straightSegment4.replace("M", "L");
+                break;
+        }
+
+        const handleConditionDragStart = (e: MouseEvent) => {
+            e.stopPropagation();
+            e.preventDefault();
+
+            flowPaneRef.current = document.querySelector(
+                ".react-flow__viewport"
+            );
+
+            if (flowPaneRef.current) {
+                const transformStyle = window.getComputedStyle(
+                    flowPaneRef.current
+                ).transform;
+                transformMatrixRef.current =
+                    parseTransformMatrix(transformStyle);
+
+                const mousePosition = clientToFlowPosition(
+                    e.clientX,
+                    e.clientY,
+                    transformMatrixRef.current
+                );
+
+                const offsetX = conditionLabelX - mousePosition.x;
+                const offsetY = conditionLabelY - mousePosition.y;
+
+                dragOffsetRef.current = { x: offsetX, y: offsetY };
+                setIsConditionDragging(true);
+                document.body.style.cursor = "grabbing";
+            }
+        };
+
+        const handleConditionDrag = useCallback(
+            throttle((e: MouseEvent) => {
+                if (!isConditionDragging || !dragOffsetRef.current) return;
+
+                e.preventDefault();
+                e.stopPropagation();
+
+                if (!flowPaneRef.current) {
+                    flowPaneRef.current = document.querySelector(
+                        ".react-flow__viewport"
+                    );
+                }
+
+                if (flowPaneRef.current) {
+                    if (!transformMatrixRef.current) {
+                        const transformStyle = window.getComputedStyle(
+                            flowPaneRef.current
+                        ).transform;
+                        transformMatrixRef.current =
+                            parseTransformMatrix(transformStyle);
+                    }
+
+                    const mousePosition = clientToFlowPosition(
+                        e.clientX,
+                        e.clientY,
+                        transformMatrixRef.current
+                    );
+
+                    const rawPosition = {
+                        x: mousePosition.x + dragOffsetRef.current.x,
+                        y: mousePosition.y + dragOffsetRef.current.y,
+                    };
+
+                    const snappedPosition = {
+                        x: snapToGrid(rawPosition.x),
+                        y: snapToGrid(rawPosition.y),
+                    };
+
+                    setTempConditionPosition(snappedPosition);
+                }
+            }, 16),
+            [isConditionDragging]
+        );
+
+        const handleConditionDragEnd = useCallback(() => {
+            if (isConditionDragging && tempConditionPosition) {
+                const newOffset = {
+                    x: tempConditionPosition.x - conditionMarkerX,
+                    y: tempConditionPosition.y - conditionMarkerY,
+                };
+
+                const updatedData = {
+                    ...data,
+                    conditionLabelOffset: newOffset,
+                };
+
+                const command = commandController.createUpdateEdgeCommand(id, {
+                    data: updatedData,
+                });
+                commandController.execute(command);
+            }
+
+            setIsConditionDragging(false);
+            setTempConditionPosition(null);
+            dragOffsetRef.current = null;
+            document.body.style.cursor = "";
+        }, [
+            isConditionDragging,
+            tempConditionPosition,
+            data,
+            id,
+            conditionMarkerX,
+            conditionMarkerY,
+        ]);
+
+        const handleDragStart =
+            (controlPointIndex: number) => (e: MouseEvent) => {
+                e.stopPropagation();
+                e.preventDefault();
+
+                flowPaneRef.current = document.querySelector(
+                    ".react-flow__viewport"
+                );
+
+                if (flowPaneRef.current) {
+                    const transformStyle = window.getComputedStyle(
+                        flowPaneRef.current
+                    ).transform;
+                    transformMatrixRef.current =
+                        parseTransformMatrix(transformStyle);
+
+                    const currentControlPoint =
+                        controlPointIndex === 1
+                            ? controlPoint1
+                            : controlPointIndex === 2
+                            ? controlPoint2
+                            : controlPoint3;
+
+                    const mousePosition = clientToFlowPosition(
+                        e.clientX,
+                        e.clientY,
+                        transformMatrixRef.current
+                    );
+
+                    const offsetX = currentControlPoint.x - mousePosition.x;
+                    const offsetY = currentControlPoint.y - mousePosition.y;
+
+                    dragOffsetRef.current = { x: offsetX, y: offsetY };
+                    setIsDragging(controlPointIndex);
+                    document.body.style.cursor = "grabbing";
+                }
+            };
+
+        const handleDrag = useCallback(
+            throttle((e: MouseEvent) => {
+                if (isDragging === null || !dragOffsetRef.current) return;
+
+                e.preventDefault();
+                e.stopPropagation();
+
+                if (!flowPaneRef.current) {
+                    flowPaneRef.current = document.querySelector(
+                        ".react-flow__viewport"
+                    );
+                }
+
+                if (flowPaneRef.current) {
+                    if (!transformMatrixRef.current) {
+                        const transformStyle = window.getComputedStyle(
+                            flowPaneRef.current
+                        ).transform;
+                        transformMatrixRef.current =
+                            parseTransformMatrix(transformStyle);
+                    }
+
+                    const mousePosition = clientToFlowPosition(
+                        e.clientX,
+                        e.clientY,
+                        transformMatrixRef.current
+                    );
+
+                    const rawPosition = {
+                        x: mousePosition.x + dragOffsetRef.current.x,
+                        y: mousePosition.y + dragOffsetRef.current.y,
+                    };
+
+                    const snappedPosition = {
+                        x: snapToGrid(rawPosition.x),
+                        y: snapToGrid(rawPosition.y),
+                    };
+
+                    setTempControlPoints((prev) => ({
+                        ...prev,
+                        [`cp${isDragging}`]: snappedPosition,
+                    }));
+                }
+            }, 16),
+            [isDragging]
+        );
+
+        const handleDragEnd = useCallback(() => {
+            if (
+                isDragging !== null &&
+                tempControlPoints[
+                    `cp${isDragging}` as keyof typeof tempControlPoints
+                ]
+            ) {
+                const updatedData = {
+                    ...data,
+                    [`controlPoint${isDragging}`]:
+                        tempControlPoints[
+                            `cp${isDragging}` as keyof typeof tempControlPoints
+                        ],
+                };
+
+                const command = commandController.createUpdateEdgeCommand(id, {
+                    data: updatedData,
+                });
+                commandController.execute(command);
+            }
+
+            setIsDragging(null);
+            setTempControlPoints({});
+            dragOffsetRef.current = null;
+            document.body.style.cursor = "";
+        }, [isDragging, tempControlPoints, data, id]);
+
+        useEffect(() => {
+            if (isDragging !== null) {
+                window.addEventListener("mousemove", handleDrag as any);
+                window.addEventListener("mouseup", handleDragEnd);
+
+                return () => {
+                    window.removeEventListener("mousemove", handleDrag as any);
+                    window.removeEventListener("mouseup", handleDragEnd);
+                };
+            }
+        }, [isDragging, handleDrag, handleDragEnd]);
+
+        useEffect(() => {
+            if (isConditionDragging) {
+                window.addEventListener(
+                    "mousemove",
+                    handleConditionDrag as any
+                );
+                window.addEventListener("mouseup", handleConditionDragEnd);
+
+                return () => {
+                    window.removeEventListener(
+                        "mousemove",
+                        handleConditionDrag as any
+                    );
+                    window.removeEventListener(
+                        "mouseup",
+                        handleConditionDragEnd
+                    );
+                };
+            }
+        }, [isConditionDragging, handleConditionDrag, handleConditionDragEnd]);
+
+        return (
+            <>
+                {/* Selected Outline */}
+                {selected && (
+                    <path
+                        d={edgePath}
+                        style={{
+                            stroke: "#93c5fd",
+                            strokeWidth: 6,
+                            strokeOpacity: 0.5,
+                            fill: "none",
+                        }}
+                    />
+                )}
+
+                {/* Main Edge Path */}
+                <BaseEdge
+                    id={id}
+                    path={edgePath}
+                    markerEnd={markerEnd}
+                    style={edgeStyle}
+                />
+
+                {/* Control Points */}
+                {selected && (
+                    <EdgeLabelRenderer>
+                        {/* Control Point 1 */}
+                        <div
+                            style={{
+                                position: "absolute",
+                                transform: `translate(-50%, -50%) translate(${controlPoint1.x}px,${controlPoint1.y}px)`,
+                                pointerEvents: "all",
+                                cursor: isDragging === 1 ? "grabbing" : "grab",
+                            }}
+                            className="nodrag nopan"
+                            onMouseDown={handleDragStart(1)}
+                        >
+                            <div
+                                className={`w-3 h-3 rounded-full border-2 ${
+                                    isDragging === 1
+                                        ? "bg-blue-500 border-blue-600"
+                                        : "bg-white border-blue-500"
+                                } shadow-md hover:scale-110 transition-transform`}
+                            />
+                        </div>
+
+                        {/* Control Point 2 */}
+                        <div
+                            style={{
+                                position: "absolute",
+                                transform: `translate(-50%, -50%) translate(${controlPoint2.x}px,${controlPoint2.y}px)`,
+                                pointerEvents: "all",
+                                cursor: isDragging === 2 ? "grabbing" : "grab",
+                            }}
+                            className="nodrag nopan"
+                            onMouseDown={handleDragStart(2)}
+                        >
+                            {!showConditionMarker && (
+                                <div
+                                    className={`w-3 h-3 rounded-full border-2 ${
+                                        isDragging === 2
+                                            ? "bg-blue-500 border-blue-600"
+                                            : "bg-white border-blue-500"
+                                    } shadow-md hover:scale-110 transition-transform`}
+                                />
+                            )}
+                        </div>
+
+                        {/* Control Point 3 */}
+                        <div
+                            style={{
+                                position: "absolute",
+                                transform: `translate(-50%, -50%) translate(${controlPoint3.x}px,${controlPoint3.y}px)`,
+                                pointerEvents: "all",
+                                cursor: isDragging === 3 ? "grabbing" : "grab",
+                            }}
+                            className="nodrag nopan"
+                            onMouseDown={handleDragStart(3)}
+                        >
+                            <div
+                                className={`w-3 h-3 rounded-full border-2 ${
+                                    isDragging === 3
+                                        ? "bg-blue-500 border-blue-600"
+                                        : "bg-white border-blue-500"
+                                } shadow-md hover:scale-110 transition-transform`}
+                            />
+                        </div>
+                    </EdgeLabelRenderer>
+                )}
+
+                {/* Conditional Marker and Label */}
+                {showConditionMarker && (
+                    <EdgeLabelRenderer>
+                        {/* Draggable Condition Marker */}
+                        {selected && (
+                            <div
+                                style={{
+                                    position: "absolute",
+                                    transform: `translate(-50%, -50%) translate(${conditionMarkerX}px,${conditionMarkerY}px)`,
+                                    pointerEvents: "all",
+                                    cursor:
+                                        isDragging === 2 ? "grabbing" : "grab",
+                                }}
+                                className="nodrag nopan"
+                                onMouseDown={handleDragStart(2)}
+                            >
+                                <div
+                                    className={`w-3 h-3 rounded-full border-2 ${
+                                        isDragging === 2
+                                            ? "bg-blue-500 border-blue-600"
+                                            : "bg-white border-blue-500"
+                                    } shadow-md hover:scale-110 transition-transform`}
+                                />
+                            </div>
+                        )}
+
+                        {/* Condition Squiggle Marker */}
+                        <div
+                            style={{
+                                position: "absolute",
+                                transform: `translate(-50%, -50%) translate(${conditionMarkerX}px,${conditionMarkerY}px) rotate(${
+                                    conditionMarkerAngle + 90
+                                }deg)`,
+                                pointerEvents: "none",
+                            }}
+                            className="nodrag nopan"
+                        >
+                            <svg
+                                width="24"
+                                height="16"
+                                viewBox="-6 -5 12 10"
+                                className={
+                                    selected
+                                        ? "stroke-blue-500"
+                                        : "stroke-gray-600 dark:stroke-gray-400"
+                                }
+                            >
+                                <path
+                                    d="M -5 0 Q -2.5 -4 0 0 Q 2.5 4 5 0"
+                                    strokeWidth="1.5"
+                                    fill="none"
+                                />
+                            </svg>
+                        </div>
+
+                        {/* Draggable Condition Label */}
+                        <div
+                            style={{
+                                position: "absolute",
+                                transform: `translate(-50%, -50%) translate(${conditionLabelX}px,${conditionLabelY}px)`,
+                                pointerEvents: selected ? "all" : "none",
+                                cursor: isConditionDragging
+                                    ? "grabbing"
+                                    : selected
+                                    ? "grab"
+                                    : "default",
+                            }}
+                            className="nodrag nopan"
+                            onMouseDown={
+                                selected ? handleConditionDragStart : undefined
+                            }
+                        >
+                            <div
+                                className={`edge-label flex justify-center items-center ${
+                                    selected
+                                        ? "bg-blue-50 dark:bg-blue-900/50"
+                                        : "bg-white/70 dark:bg-zinc-800/70"
+                                } p-1 rounded text-xs ${
+                                    selected
+                                        ? "shadow-md border border-blue-300 dark:border-blue-600"
+                                        : "shadow"
+                                } ${isConditionDragging ? "opacity-70" : ""}`}
+                                style={{
+                                    minWidth: "20px",
+                                    backdropFilter: "blur(4px)",
+                                }}
+                            >
+                                <MathJax>{data?.condition || "True"}</MathJax>
+                            </div>
+                        </div>
+                    </EdgeLabelRenderer>
+                )}
+            </>
+        );
+    }
+) as any;
+
+RCQEdge.getDefaultData = (): RCQEdgeData => ({
+    edgeType: "straight",
+    condition: "True",
+    conditionLabelOffset: { x: 0, y: -30 },
+});
+
+RCQEdge.getGraphType = (): string => "rcq";
+
+RCQEdge.displayName = "RCQEdge";
+
+export default RCQEdge;

--- a/src/components/edges/index.ts
+++ b/src/components/edges/index.ts
@@ -1,14 +1,17 @@
 import EventGraphEdge from "./eventbased/EventGraphEdge";
 import InitializationEdge from "./eventbased/InitializationEdge";
+import RCQEdge from "./activitybased/resourceconstrained/RCQEdge";
 
 export const EDGE_TYPES = {
     EVENT_GRAPH: "eventGraph",
     INITIALIZATION: "initialization",
+    RCQ: "rcq",
 } as const;
 
 export const edgeTypes = {
     eventGraph: EventGraphEdge,
     initialization: InitializationEdge,
+    rcq: RCQEdge,
 } as const;
 
-export { EventGraphEdge, InitializationEdge };
+export { EventGraphEdge, InitializationEdge, RCQEdge };

--- a/src/components/nodes/activitybased/resourceconstrainedqueues/ActivityNode.tsx
+++ b/src/components/nodes/activitybased/resourceconstrainedqueues/ActivityNode.tsx
@@ -364,7 +364,7 @@ const ActivityNode = memo(
                     )}
                 </div>
 
-                {id !== "preview" && isHovered && (
+                {id !== "preview" && (
                     <>
                         {/* Top handles */}
                         {handlePositions.top.map((leftPos, index) => (
@@ -373,7 +373,11 @@ const ActivityNode = memo(
                                 id={`${id}-top-${index}`}
                                 type="source"
                                 position={Position.Top}
-                                className="!bg-transparent !border-none !w-3 !h-3 before:content-[''] before:absolute before:w-full before:h-0.5 before:bg-blue-500 dark:before:bg-blue-400 before:top-1/2 before:left-0 before:-translate-y-1/2 before:rotate-45 after:content-[''] after:absolute after:w-0.5 after:h-full after:bg-blue-500 dark:after:bg-blue-400 after:left-1/2 after:top-0 after:-translate-x-1/2 after:rotate-45"
+                                className={`!border-none !w-3 !h-3 before:content-[''] before:absolute before:w-full before:h-0.5 before:bg-blue-500 dark:before:bg-blue-400 before:top-1/2 before:left-0 before:-translate-y-1/2 before:rotate-45 after:content-[''] after:absolute after:w-0.5 after:h-full after:bg-blue-500 dark:after:bg-blue-400 after:left-1/2 after:top-0 after:-translate-x-1/2 after:rotate-45 ${
+                                    selected || isHovered
+                                        ? "!bg-transparent"
+                                        : "!bg-transparent !opacity-0"
+                                }`}
                                 isConnectable={isConnectable}
                                 style={{
                                     left: `${leftPos}px`,
@@ -390,7 +394,11 @@ const ActivityNode = memo(
                                 id={`${id}-right-${index}`}
                                 type="source"
                                 position={Position.Right}
-                                className="!bg-transparent !border-none !w-3 !h-3 before:content-[''] before:absolute before:w-full before:h-0.5 before:bg-blue-500 dark:before:bg-blue-400 before:top-1/2 before:left-0 before:-translate-y-1/2 before:rotate-45 after:content-[''] after:absolute after:w-0.5 after:h-full after:bg-blue-500 dark:after:bg-blue-400 after:left-1/2 after:top-0 after:-translate-x-1/2 after:rotate-45"
+                                className={`!border-none !w-3 !h-3 before:content-[''] before:absolute before:w-full before:h-0.5 before:bg-blue-500 dark:before:bg-blue-400 before:top-1/2 before:left-0 before:-translate-y-1/2 before:rotate-45 after:content-[''] after:absolute after:w-0.5 after:h-full after:bg-blue-500 dark:after:bg-blue-400 after:left-1/2 after:top-0 after:-translate-x-1/2 after:rotate-45 ${
+                                    selected || isHovered
+                                        ? "!bg-transparent"
+                                        : "!bg-transparent !opacity-0"
+                                }`}
                                 isConnectable={isConnectable}
                                 style={{
                                     left: `${dimensions.width}px`,
@@ -407,7 +415,11 @@ const ActivityNode = memo(
                                 id={`${id}-bottom-${index}`}
                                 type="source"
                                 position={Position.Bottom}
-                                className="!bg-transparent !border-none !w-3 !h-3 before:content-[''] before:absolute before:w-full before:h-0.5 before:bg-blue-500 dark:before:bg-blue-400 before:top-1/2 before:left-0 before:-translate-y-1/2 before:rotate-45 after:content-[''] after:absolute after:w-0.5 after:h-full after:bg-blue-500 dark:after:bg-blue-400 after:left-1/2 after:top-0 after:-translate-x-1/2 after:rotate-45"
+                                className={`!border-none !w-3 !h-3 before:content-[''] before:absolute before:w-full before:h-0.5 before:bg-blue-500 dark:before:bg-blue-400 before:top-1/2 before:left-0 before:-translate-y-1/2 before:rotate-45 after:content-[''] after:absolute after:w-0.5 after:h-full after:bg-blue-500 dark:after:bg-blue-400 after:left-1/2 after:top-0 after:-translate-x-1/2 after:rotate-45 ${
+                                    selected || isHovered
+                                        ? "!bg-transparent"
+                                        : "!bg-transparent !opacity-0"
+                                }`}
                                 isConnectable={isConnectable}
                                 style={{
                                     left: `${leftPos}px`,
@@ -424,7 +436,11 @@ const ActivityNode = memo(
                                 id={`${id}-left-${index}`}
                                 type="target"
                                 position={Position.Left}
-                                className="!bg-transparent !border-none !w-3 !h-3 before:content-[''] before:absolute before:w-full before:h-0.5 before:bg-blue-500 dark:before:bg-blue-400 before:top-1/2 before:left-0 before:-translate-y-1/2 before:rotate-45 after:content-[''] after:absolute after:w-0.5 after:h-full after:bg-blue-500 dark:after:bg-blue-400 after:left-1/2 after:top-0 after:-translate-x-1/2 after:rotate-45"
+                                className={`!border-none !w-3 !h-3 before:content-[''] before:absolute before:w-full before:h-0.5 before:bg-blue-500 dark:before:bg-blue-400 before:top-1/2 before:left-0 before:-translate-y-1/2 before:rotate-45 after:content-[''] after:absolute after:w-0.5 after:h-full after:bg-blue-500 dark:after:bg-blue-400 after:left-1/2 after:top-0 after:-translate-x-1/2 after:rotate-45 ${
+                                    selected || isHovered
+                                        ? "!bg-transparent"
+                                        : "!bg-transparent !opacity-0"
+                                }`}
                                 isConnectable={isConnectable}
                                 style={{
                                     left: "0px",
@@ -487,7 +503,7 @@ ActivityNode.getDefaultData = (): ActivityNodeData => ({
     duration: "op time",
 });
 
-ActivityNode.getGraphType = (): string => "activityBased";
+ActivityNode.getGraphType = (): string => "rcq";
 
 ActivityNode.displayName = "ActivityNode";
 

--- a/src/components/nodes/activitybased/resourceconstrainedqueues/GeneratorNode.tsx
+++ b/src/components/nodes/activitybased/resourceconstrainedqueues/GeneratorNode.tsx
@@ -67,7 +67,7 @@ export const GeneratorNodePreview = () => {
             </svg>
 
             {/* Content Area */}
-            <div className="absolute inset-0 flex items-center justify-center text-center dark:text-white text-black px-8">
+            <div className="absolute inset-0 flex items-center justify-center text-center dark:text-white text-black px-4">
                 <span>Load 1</span>
             </div>
         </div>
@@ -118,18 +118,22 @@ const GeneratorNode = memo(
                 </svg>
 
                 {/* Content Area */}
-                <div className="absolute inset-0 flex items-center justify-center text-center dark:text-white text-black px-8">
+                <div className="absolute inset-0 flex items-center justify-center text-center dark:text-white text-black px-4 text-sm left-4">
                     <MathJax>{nodeName}</MathJax>
                 </div>
 
-                {id !== "preview" && (selected || isHovered) && (
+                {id !== "preview" && (
                     <>
                         {/* Top Handles */}
                         <Handle
                             id={`${id}-top-left-source`}
                             type="source"
                             position={Position.Top}
-                            className="!bg-transparent !border-none !w-3 !h-3 before:content-[''] before:absolute before:w-full before:h-0.5 before:bg-blue-500 dark:before:bg-blue-400 before:top-1/2 before:left-0 before:-translate-y-1/2 before:rotate-45 after:content-[''] after:absolute after:w-0.5 after:h-full after:bg-blue-500 dark:after:bg-blue-400 after:left-1/2 after:top-0 after:-translate-x-1/2 after:rotate-45"
+                            className={`!border-none !w-3 !h-3 before:content-[''] before:absolute before:w-full before:h-0.5 before:bg-blue-500 dark:before:bg-blue-400 before:top-1/2 before:left-0 before:-translate-y-1/2 before:rotate-45 after:content-[''] after:absolute after:w-0.5 after:h-full after:bg-blue-500 dark:after:bg-blue-400 after:left-1/2 after:top-0 after:-translate-x-1/2 after:rotate-45 ${
+                                selected || isHovered
+                                    ? "!bg-transparent"
+                                    : "!bg-transparent !opacity-0"
+                            }`}
                             isConnectable={isConnectable}
                             style={{
                                 left: "-3%",
@@ -142,7 +146,11 @@ const GeneratorNode = memo(
                             id={`${id}-top-center-source`}
                             type="source"
                             position={Position.Top}
-                            className="!bg-transparent !border-none !w-3 !h-3 before:content-[''] before:absolute before:w-full before:h-0.5 before:bg-blue-500 dark:before:bg-blue-400 before:top-1/2 before:left-0 before:-translate-y-1/2 before:rotate-45 after:content-[''] after:absolute after:w-0.5 after:h-full after:bg-blue-500 dark:after:bg-blue-400 after:left-1/2 after:top-0 after:-translate-x-1/2 after:rotate-45"
+                            className={`!border-none !w-3 !h-3 before:content-[''] before:absolute before:w-full before:h-0.5 before:bg-blue-500 dark:before:bg-blue-400 before:top-1/2 before:left-0 before:-translate-y-1/2 before:rotate-45 after:content-[''] after:absolute after:w-0.5 after:h-full after:bg-blue-500 dark:after:bg-blue-400 after:left-1/2 after:top-0 after:-translate-x-1/2 after:rotate-45 ${
+                                selected || isHovered
+                                    ? "!bg-transparent"
+                                    : "!bg-transparent !opacity-0"
+                            }`}
                             isConnectable={isConnectable}
                             style={{
                                 left: "37.5%",
@@ -155,7 +163,11 @@ const GeneratorNode = memo(
                             id={`${id}-top-right-source`}
                             type="source"
                             position={Position.Top}
-                            className="!bg-transparent !border-none !w-3 !h-3 before:content-[''] before:absolute before:w-full before:h-0.5 before:bg-blue-500 dark:before:bg-blue-400 before:top-1/2 before:left-0 before:-translate-y-1/2 before:rotate-45 after:content-[''] after:absolute after:w-0.5 after:h-full after:bg-blue-500 dark:after:bg-blue-400 after:left-1/2 after:top-0 after:-translate-x-1/2 after:rotate-45"
+                            className={`!border-none !w-3 !h-3 before:content-[''] before:absolute before:w-full before:h-0.5 before:bg-blue-500 dark:before:bg-blue-400 before:top-1/2 before:left-0 before:-translate-y-1/2 before:rotate-45 after:content-[''] after:absolute after:w-0.5 after:h-full after:bg-blue-500 dark:after:bg-blue-400 after:left-1/2 after:top-0 after:-translate-x-1/2 after:rotate-45 ${
+                                selected || isHovered
+                                    ? "!bg-transparent"
+                                    : "!bg-transparent !opacity-0"
+                            }`}
                             isConnectable={isConnectable}
                             style={{
                                 left: "73%",
@@ -169,7 +181,11 @@ const GeneratorNode = memo(
                             id={`${id}-left-source`}
                             type="source"
                             position={Position.Left}
-                            className="!bg-transparent !border-none !w-3 !h-3 before:content-[''] before:absolute before:w-full before:h-0.5 before:bg-blue-500 dark:before:bg-blue-400 before:top-1/2 before:left-0 before:-translate-y-1/2 before:rotate-45 after:content-[''] after:absolute after:w-0.5 after:h-full after:bg-blue-500 dark:after:bg-blue-400 after:left-1/2 after:top-0 after:-translate-x-1/2 after:rotate-45"
+                            className={`!border-none !w-3 !h-3 before:content-[''] before:absolute before:w-full before:h-0.5 before:bg-blue-500 dark:before:bg-blue-400 before:top-1/2 before:left-0 before:-translate-y-1/2 before:rotate-45 after:content-[''] after:absolute after:w-0.5 after:h-full after:bg-blue-500 dark:after:bg-blue-400 after:left-1/2 after:top-0 after:-translate-x-1/2 after:rotate-45 ${
+                                selected || isHovered
+                                    ? "!bg-transparent"
+                                    : "!bg-transparent !opacity-0"
+                            }`}
                             isConnectable={isConnectable}
                             style={{
                                 left: "19%",
@@ -183,7 +199,11 @@ const GeneratorNode = memo(
                             id={`${id}-right-source`}
                             type="source"
                             position={Position.Right}
-                            className="!bg-transparent !border-none !w-3 !h-3 before:content-[''] before:absolute before:w-full before:h-0.5 before:bg-blue-500 dark:before:bg-blue-400 before:top-1/2 before:left-0 before:-translate-y-1/2 before:rotate-45 after:content-[''] after:absolute after:w-0.5 after:h-full after:bg-blue-500 dark:after:bg-blue-400 after:left-1/2 after:top-0 after:-translate-x-1/2 after:rotate-45"
+                            className={`!border-none !w-3 !h-3 before:content-[''] before:absolute before:w-full before:h-0.5 before:bg-blue-500 dark:before:bg-blue-400 before:top-1/2 before:left-0 before:-translate-y-1/2 before:rotate-45 after:content-[''] after:absolute after:w-0.5 after:h-full after:bg-blue-500 dark:after:bg-blue-400 after:left-1/2 after:top-0 after:-translate-x-1/2 after:rotate-45 ${
+                                selected || isHovered
+                                    ? "!bg-transparent"
+                                    : "!bg-transparent !opacity-0"
+                            }`}
                             isConnectable={isConnectable}
                             style={{
                                 right: "5%",
@@ -197,7 +217,11 @@ const GeneratorNode = memo(
                             id={`${id}-bottom-left-source`}
                             type="source"
                             position={Position.Bottom}
-                            className="!bg-transparent !border-none !w-3 !h-3 before:content-[''] before:absolute before:w-full before:h-0.5 before:bg-blue-500 dark:before:bg-blue-400 before:top-1/2 before:left-0 before:-translate-y-1/2 before:rotate-45 after:content-[''] after:absolute after:w-0.5 after:h-full after:bg-blue-500 dark:after:bg-blue-400 after:left-1/2 after:top-0 after:-translate-x-1/2 after:rotate-45"
+                            className={`!border-none !w-3 !h-3 before:content-[''] before:absolute before:w-full before:h-0.5 before:bg-blue-500 dark:before:bg-blue-400 before:top-1/2 before:left-0 before:-translate-y-1/2 before:rotate-45 after:content-[''] after:absolute after:w-0.5 after:h-full after:bg-blue-500 dark:after:bg-blue-400 after:left-1/2 after:top-0 after:-translate-x-1/2 after:rotate-45 ${
+                                selected || isHovered
+                                    ? "!bg-transparent"
+                                    : "!bg-transparent !opacity-0"
+                            }`}
                             isConnectable={isConnectable}
                             style={{
                                 left: "-3%",
@@ -210,7 +234,11 @@ const GeneratorNode = memo(
                             id={`${id}-bottom-center-source`}
                             type="source"
                             position={Position.Bottom}
-                            className="!bg-transparent !border-none !w-3 !h-3 before:content-[''] before:absolute before:w-full before:h-0.5 before:bg-blue-500 dark:before:bg-blue-400 before:top-1/2 before:left-0 before:-translate-y-1/2 before:rotate-45 after:content-[''] after:absolute after:w-0.5 after:h-full after:bg-blue-500 dark:after:bg-blue-400 after:left-1/2 after:top-0 after:-translate-x-1/2 after:rotate-45"
+                            className={`!border-none !w-3 !h-3 before:content-[''] before:absolute before:w-full before:h-0.5 before:bg-blue-500 dark:before:bg-blue-400 before:top-1/2 before:left-0 before:-translate-y-1/2 before:rotate-45 after:content-[''] after:absolute after:w-0.5 after:h-full after:bg-blue-500 dark:after:bg-blue-400 after:left-1/2 after:top-0 after:-translate-x-1/2 after:rotate-45 ${
+                                selected || isHovered
+                                    ? "!bg-transparent"
+                                    : "!bg-transparent !opacity-0"
+                            }`}
                             isConnectable={isConnectable}
                             style={{
                                 left: "37.5%",
@@ -223,7 +251,11 @@ const GeneratorNode = memo(
                             id={`${id}-bottom-right-source`}
                             type="source"
                             position={Position.Bottom}
-                            className="!bg-transparent !border-none !w-3 !h-3 before:content-[''] before:absolute before:w-full before:h-0.5 before:bg-blue-500 dark:before:bg-blue-400 before:top-1/2 before:left-0 before:-translate-y-1/2 before:rotate-45 after:content-[''] after:absolute after:w-0.5 after:h-full after:bg-blue-500 dark:after:bg-blue-400 after:left-1/2 after:top-0 after:-translate-x-1/2 after:rotate-45"
+                            className={`!border-none !w-3 !h-3 before:content-[''] before:absolute before:w-full before:h-0.5 before:bg-blue-500 dark:before:bg-blue-400 before:top-1/2 before:left-0 before:-translate-y-1/2 before:rotate-45 after:content-[''] after:absolute after:w-0.5 after:h-full after:bg-blue-500 dark:after:bg-blue-400 after:left-1/2 after:top-0 after:-translate-x-1/2 after:rotate-45 ${
+                                selected || isHovered
+                                    ? "!bg-transparent"
+                                    : "!bg-transparent !opacity-0"
+                            }`}
                             isConnectable={isConnectable}
                             style={{
                                 left: "73%",
@@ -264,7 +296,7 @@ const GeneratorNode = memo(
 
 GeneratorNode.getDefaultData = (): GeneratorNodeData => ({});
 
-GeneratorNode.getGraphType = (): string => "activityBased";
+GeneratorNode.getGraphType = (): string => "rcq";
 
 GeneratorNode.displayName = "GeneratorNode";
 

--- a/src/components/nodes/activitybased/resourceconstrainedqueues/TerminatorNode.tsx
+++ b/src/components/nodes/activitybased/resourceconstrainedqueues/TerminatorNode.tsx
@@ -128,14 +128,18 @@ const TerminatorNode = memo(
                     <MathJax>{nodeName}</MathJax>
                 </div>
 
-                {id !== "preview" && (selected || isHovered) && (
+                {id !== "preview" && (
                     <>
                         {/* Top Handles - 3 handles */}
                         <Handle
                             id={`${id}-top-left-target`}
                             type="target"
                             position={Position.Top}
-                            className="!bg-transparent !border-none !w-3 !h-3 before:content-[''] before:absolute before:w-full before:h-0.5 before:bg-blue-500 dark:before:bg-blue-400 before:top-1/2 before:left-0 before:-translate-y-1/2 before:rotate-45 after:content-[''] after:absolute after:w-0.5 after:h-full after:bg-blue-500 dark:after:bg-blue-400 after:left-1/2 after:top-0 after:-translate-x-1/2 after:rotate-45"
+                            className={`!border-none !w-3 !h-3 before:content-[''] before:absolute before:w-full before:h-0.5 before:bg-blue-500 dark:before:bg-blue-400 before:top-1/2 before:left-0 before:-translate-y-1/2 before:rotate-45 after:content-[''] after:absolute after:w-0.5 after:h-full after:bg-blue-500 dark:after:bg-blue-400 after:left-1/2 after:top-0 after:-translate-x-1/2 after:rotate-45 ${
+                                selected || isHovered
+                                    ? "!bg-transparent"
+                                    : "!bg-transparent !opacity-0"
+                            }`}
                             isConnectable={isConnectable}
                             style={{
                                 left: "20%",
@@ -147,7 +151,11 @@ const TerminatorNode = memo(
                             id={`${id}-top-center-target`}
                             type="target"
                             position={Position.Top}
-                            className="!bg-transparent !border-none !w-3 !h-3 before:content-[''] before:absolute before:w-full before:h-0.5 before:bg-blue-500 dark:before:bg-blue-400 before:top-1/2 before:left-0 before:-translate-y-1/2 before:rotate-45 after:content-[''] after:absolute after:w-0.5 after:h-full after:bg-blue-500 dark:after:bg-blue-400 after:left-1/2 after:top-0 after:-translate-x-1/2 after:rotate-45"
+                            className={`!border-none !w-3 !h-3 before:content-[''] before:absolute before:w-full before:h-0.5 before:bg-blue-500 dark:before:bg-blue-400 before:top-1/2 before:left-0 before:-translate-y-1/2 before:rotate-45 after:content-[''] after:absolute after:w-0.5 after:h-full after:bg-blue-500 dark:after:bg-blue-400 after:left-1/2 after:top-0 after:-translate-x-1/2 after:rotate-45 ${
+                                selected || isHovered
+                                    ? "!bg-transparent"
+                                    : "!bg-transparent !opacity-0"
+                            }`}
                             isConnectable={isConnectable}
                             style={{
                                 left: "50%",
@@ -159,7 +167,11 @@ const TerminatorNode = memo(
                             id={`${id}-top-right-target`}
                             type="target"
                             position={Position.Top}
-                            className="!bg-transparent !border-none !w-3 !h-3 before:content-[''] before:absolute before:w-full before:h-0.5 before:bg-blue-500 dark:before:bg-blue-400 before:top-1/2 before:left-0 before:-translate-y-1/2 before:rotate-45 after:content-[''] after:absolute after:w-0.5 after:h-full after:bg-blue-500 dark:after:bg-blue-400 after:left-1/2 after:top-0 after:-translate-x-1/2 after:rotate-45"
+                            className={`!border-none !w-3 !h-3 before:content-[''] before:absolute before:w-full before:h-0.5 before:bg-blue-500 dark:before:bg-blue-400 before:top-1/2 before:left-0 before:-translate-y-1/2 before:rotate-45 after:content-[''] after:absolute after:w-0.5 after:h-full after:bg-blue-500 dark:after:bg-blue-400 after:left-1/2 after:top-0 after:-translate-x-1/2 after:rotate-45 ${
+                                selected || isHovered
+                                    ? "!bg-transparent"
+                                    : "!bg-transparent !opacity-0"
+                            }`}
                             isConnectable={isConnectable}
                             style={{
                                 left: "80%",
@@ -173,7 +185,11 @@ const TerminatorNode = memo(
                             id={`${id}-left-target`}
                             type="target"
                             position={Position.Left}
-                            className="!bg-transparent !border-none !w-3 !h-3 before:content-[''] before:absolute before:w-full before:h-0.5 before:bg-blue-500 dark:before:bg-blue-400 before:top-1/2 before:left-0 before:-translate-y-1/2 before:rotate-45 after:content-[''] after:absolute after:w-0.5 after:h-full after:bg-blue-500 dark:after:bg-blue-400 after:left-1/2 after:top-0 after:-translate-x-1/2 after:rotate-45"
+                            className={`!border-none !w-3 !h-3 before:content-[''] before:absolute before:w-full before:h-0.5 before:bg-blue-500 dark:before:bg-blue-400 before:top-1/2 before:left-0 before:-translate-y-1/2 before:rotate-45 after:content-[''] after:absolute after:w-0.5 after:h-full after:bg-blue-500 dark:after:bg-blue-400 after:left-1/2 after:top-0 after:-translate-x-1/2 after:rotate-45 ${
+                                selected || isHovered
+                                    ? "!bg-transparent"
+                                    : "!bg-transparent !opacity-0"
+                            }`}
                             isConnectable={isConnectable}
                             style={{
                                 left: "2.5%",
@@ -187,7 +203,11 @@ const TerminatorNode = memo(
                             id={`${id}-right-target`}
                             type="target"
                             position={Position.Right}
-                            className="!bg-transparent !border-none !w-3 !h-3 before:content-[''] before:absolute before:w-full before:h-0.5 before:bg-blue-500 dark:before:bg-blue-400 before:top-1/2 before:left-0 before:-translate-y-1/2 before:rotate-45 after:content-[''] after:absolute after:w-0.5 after:h-full after:bg-blue-500 dark:after:bg-blue-400 after:left-1/2 after:top-0 after:-translate-x-1/2 after:rotate-45"
+                            className={`!border-none !w-3 !h-3 before:content-[''] before:absolute before:w-full before:h-0.5 before:bg-blue-500 dark:before:bg-blue-400 before:top-1/2 before:left-0 before:-translate-y-1/2 before:rotate-45 after:content-[''] after:absolute after:w-0.5 after:h-full after:bg-blue-500 dark:after:bg-blue-400 after:left-1/2 after:top-0 after:-translate-x-1/2 after:rotate-45 ${
+                                selected || isHovered
+                                    ? "!bg-transparent"
+                                    : "!bg-transparent !opacity-0"
+                            }`}
                             isConnectable={isConnectable}
                             style={{
                                 right: "2.5%",
@@ -201,7 +221,11 @@ const TerminatorNode = memo(
                             id={`${id}-bottom-left-target`}
                             type="target"
                             position={Position.Bottom}
-                            className="!bg-transparent !border-none !w-3 !h-3 before:content-[''] before:absolute before:w-full before:h-0.5 before:bg-blue-500 dark:before:bg-blue-400 before:top-1/2 before:left-0 before:-translate-y-1/2 before:rotate-45 after:content-[''] after:absolute after:w-0.5 after:h-full after:bg-blue-500 dark:after:bg-blue-400 after:left-1/2 after:top-0 after:-translate-x-1/2 after:rotate-45"
+                            className={`!border-none !w-3 !h-3 before:content-[''] before:absolute before:w-full before:h-0.5 before:bg-blue-500 dark:before:bg-blue-400 before:top-1/2 before:left-0 before:-translate-y-1/2 before:rotate-45 after:content-[''] after:absolute after:w-0.5 after:h-full after:bg-blue-500 dark:after:bg-blue-400 after:left-1/2 after:top-0 after:-translate-x-1/2 after:rotate-45 ${
+                                selected || isHovered
+                                    ? "!bg-transparent"
+                                    : "!bg-transparent !opacity-0"
+                            }`}
                             isConnectable={isConnectable}
                             style={{
                                 left: "20%",
@@ -213,7 +237,11 @@ const TerminatorNode = memo(
                             id={`${id}-bottom-center-target`}
                             type="target"
                             position={Position.Bottom}
-                            className="!bg-transparent !border-none !w-3 !h-3 before:content-[''] before:absolute before:w-full before:h-0.5 before:bg-blue-500 dark:before:bg-blue-400 before:top-1/2 before:left-0 before:-translate-y-1/2 before:rotate-45 after:content-[''] after:absolute after:w-0.5 after:h-full after:bg-blue-500 dark:after:bg-blue-400 after:left-1/2 after:top-0 after:-translate-x-1/2 after:rotate-45"
+                            className={`!border-none !w-3 !h-3 before:content-[''] before:absolute before:w-full before:h-0.5 before:bg-blue-500 dark:before:bg-blue-400 before:top-1/2 before:left-0 before:-translate-y-1/2 before:rotate-45 after:content-[''] after:absolute after:w-0.5 after:h-full after:bg-blue-500 dark:after:bg-blue-400 after:left-1/2 after:top-0 after:-translate-x-1/2 after:rotate-45 ${
+                                selected || isHovered
+                                    ? "!bg-transparent"
+                                    : "!bg-transparent !opacity-0"
+                            }`}
                             isConnectable={isConnectable}
                             style={{
                                 left: "50%",
@@ -225,7 +253,11 @@ const TerminatorNode = memo(
                             id={`${id}-bottom-right-target`}
                             type="target"
                             position={Position.Bottom}
-                            className="!bg-transparent !border-none !w-3 !h-3 before:content-[''] before:absolute before:w-full before:h-0.5 before:bg-blue-500 dark:before:bg-blue-400 before:top-1/2 before:left-0 before:-translate-y-1/2 before:rotate-45 after:content-[''] after:absolute after:w-0.5 after:h-full after:bg-blue-500 dark:after:bg-blue-400 after:left-1/2 after:top-0 after:-translate-x-1/2 after:rotate-45"
+                            className={`!border-none !w-3 !h-3 before:content-[''] before:absolute before:w-full before:h-0.5 before:bg-blue-500 dark:before:bg-blue-400 before:top-1/2 before:left-0 before:-translate-y-1/2 before:rotate-45 after:content-[''] after:absolute after:w-0.5 after:h-full after:bg-blue-500 dark:after:bg-blue-400 after:left-1/2 after:top-0 after:-translate-x-1/2 after:rotate-45 ${
+                                selected || isHovered
+                                    ? "!bg-transparent"
+                                    : "!bg-transparent !opacity-0"
+                            }`}
                             isConnectable={isConnectable}
                             style={{
                                 left: "80%",
@@ -266,7 +298,7 @@ const TerminatorNode = memo(
 
 TerminatorNode.getDefaultData = (): TerminatorNodeData => ({});
 
-TerminatorNode.getGraphType = (): string => "activityBased";
+TerminatorNode.getGraphType = (): string => "rcq";
 
 TerminatorNode.displayName = "TerminatorNode";
 

--- a/src/components/nodes/eventbased/EventNode.tsx
+++ b/src/components/nodes/eventbased/EventNode.tsx
@@ -235,6 +235,7 @@ EventNode.getDefaultData = (): EventNodeData => ({
 });
 
 EventNode.getGraphType = (): string => "eventBased";
+EventNode.getType = (): string => "eventGraph";
 
 EventNode.displayName = "EventNode";
 

--- a/src/components/nodes/eventbased/InitializationNode.tsx
+++ b/src/components/nodes/eventbased/InitializationNode.tsx
@@ -23,6 +23,7 @@ interface InitializationNodeComponent
     defaultData: InitializationNodeData;
     displayName?: string;
     getGraphType?: () => string;
+    getType?: () => string;
 }
 
 interface InitializationNodeJSON {
@@ -281,6 +282,7 @@ InitializationNode.getDefaultData = (): InitializationNodeData => ({
 });
 
 InitializationNode.getGraphType = (): string => "eventBased";
+InitializationNode.getType = (): string => "eventGraph";
 
 InitializationNode.displayName = "InitializationNode";
 

--- a/src/controllers/CommandController.ts
+++ b/src/controllers/CommandController.ts
@@ -302,6 +302,9 @@ export class CommandController {
                 }
                 return "eventGraph";
 
+            case sourceGraphType === "rcq" && targetGraphType === "rcq":
+                return "rcq";
+
             default:
                 return undefined;
         }
@@ -328,11 +331,17 @@ export class CommandController {
                 parameter: "1",
                 edgeType: "straight",
             };
+        } else if (edgeType === "rcq") {
+            defaultData = {
+                edgeType: "straight",
+            };
         }
 
         let graphType: string | undefined = undefined;
         if (edgeType === "eventGraph" || edgeType === "initialization") {
             graphType = "eventBased";
+        } else if (edgeType === "rcq") {
+            graphType = "rcq";
         }
 
         const edge: BaseEdge = {

--- a/src/lib/utils/edge.ts
+++ b/src/lib/utils/edge.ts
@@ -1,6 +1,34 @@
 import { isCurveFlipped, getOffsetPoint, calculateDynamicOffset } from "./math";
 
 /**
+ * Calculate default control points for a multi-segment edge path
+ */
+export function calculateDefaultControlPoints(
+    sourceX: number,
+    sourceY: number,
+    targetX: number,
+    targetY: number
+): {
+    cp1: { x: number; y: number };
+    cp2: { x: number; y: number };
+    cp3: { x: number; y: number };
+} {
+    const cp1 = {
+        x: sourceX + (targetX - sourceX) * 0.25,
+        y: sourceY + (targetY - sourceY) * 0.25,
+    };
+    const cp2 = {
+        x: sourceX + (targetX - sourceX) * 0.5,
+        y: sourceY + (targetY - sourceY) * 0.5,
+    };
+    const cp3 = {
+        x: sourceX + (targetX - sourceX) * 0.75,
+        y: sourceY + (targetY - sourceY) * 0.75,
+    };
+    return { cp1, cp2, cp3 };
+}
+
+/**
  * Calculate an offset point for edge labels based on the edge path and parameters.
  * Takes into account the curve orientation, distance between nodes, and provides appropriate
  * offset positions for visual elements.

--- a/src/lib/utils/math.ts
+++ b/src/lib/utils/math.ts
@@ -373,3 +373,27 @@ export function projectPointOntoBezierCurve(
         };
     }
 }
+
+/**
+ * Throttle function execution to limit how often it can be called
+ */
+export function throttle<T extends (...args: any[]) => any>(
+    func: T,
+    limit: number
+): (...args: Parameters<T>) => void {
+    let lastCall = 0;
+    return function (...args: Parameters<T>) {
+        const now = Date.now();
+        if (now - lastCall >= limit) {
+            lastCall = now;
+            return func(...args);
+        }
+    };
+}
+
+/**
+ * Snap a value to the nearest grid position
+ */
+export function snapToGrid(value: number, gridSize: number = 15): number {
+    return Math.round(value / gridSize) * gridSize;
+}

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -440,15 +440,31 @@ export const useStore = create<StoreState>((set, get) => ({
                     ];
 
                     if (selectedEdge.data) {
-                        const dataProps = Object.entries(selectedEdge.data).map(
-                            ([key, value]) => {
+                        const dataProps = Object.entries(selectedEdge.data)
+                            .filter(([key]) => {
+                                if (
+                                    selectedEdge.type === "rcq" &&
+                                    (key === "controlPoint1" ||
+                                        key === "controlPoint2" ||
+                                        key === "controlPoint3" ||
+                                        key === "conditionLabelOffset")
+                                ) {
+                                    return false;
+                                }
+                                return true;
+                            })
+                            .map(([key, value]) => {
                                 if (key === "edgeType") {
                                     return {
                                         key: "edgeType",
                                         value: value as string,
                                         type: "string" as const,
                                         editable: true,
-                                        options: ["straight", "bezier"],
+                                        options: [
+                                            "straight",
+                                            "bezier",
+                                            "smoothstep",
+                                        ],
                                     };
                                 }
                                 return {
@@ -459,15 +475,62 @@ export const useStore = create<StoreState>((set, get) => ({
                                         : "string") as "number" | "string",
                                     editable: true,
                                 };
-                            }
-                        );
+                            });
+
+                        if (
+                            selectedEdge.type === "rcq" &&
+                            !selectedEdge.data.edgeType
+                        ) {
+                            dataProps.push({
+                                key: "edgeType",
+                                value: "straight",
+                                type: "string" as const,
+                                editable: true,
+                                options: ["straight", "bezier", "smoothstep"],
+                            });
+                        }
+
+                        if (
+                            selectedEdge.type === "rcq" &&
+                            !selectedEdge.data.condition
+                        ) {
+                            dataProps.push({
+                                key: "condition",
+                                value: "True",
+                                type: "string" as const,
+                                editable: true,
+                            });
+                        }
 
                         updatedProperties = [
                             ...explicitProps,
                             ...dataProps,
                         ] as SelectedProperty[];
                     } else {
-                        updatedProperties = explicitProps;
+                        if (selectedEdge.type === "rcq") {
+                            updatedProperties = [
+                                ...explicitProps,
+                                {
+                                    key: "edgeType",
+                                    value: "straight",
+                                    type: "string" as const,
+                                    editable: true,
+                                    options: [
+                                        "straight",
+                                        "bezier",
+                                        "smoothstep",
+                                    ],
+                                },
+                                {
+                                    key: "condition",
+                                    value: "True",
+                                    type: "string" as const,
+                                    editable: true,
+                                },
+                            ] as SelectedProperty[];
+                        } else {
+                            updatedProperties = explicitProps;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This pull request introduces a new `RCQEdge` type and updates the behavior and styling of `ActivityNode` and `GeneratorNode` components to support resource-constrained queue (RCQ) graphs. The changes include adding the new edge type, modifying node behavior and appearance based on selection or hover states, and updating default graph types for the nodes.

### New Edge Type
* Added `RCQEdge` to the `EDGE_TYPES` and `edgeTypes` collections in `src/components/edges/index.ts`, enabling support for resource-constrained queue edges.

### Node Behavior Updates
* Updated `ActivityNode` to remove the hover-only condition for rendering connection handles and adjusted the `getGraphType` method to return "rcq" for RCQ graphs. [[1]](diffhunk://#diff-405baa8efb297ce37bf1b40e681b1a9e44cecb37db8f8b974d96a7d67136cb1fL367-R367) [[2]](diffhunk://#diff-405baa8efb297ce37bf1b40e681b1a9e44cecb37db8f8b974d96a7d67136cb1fL490-R506)
* Updated `GeneratorNode` to remove the hover-only condition for rendering connection handles and adjusted the `getGraphType` method to return "rcq" for RCQ graphs. [[1]](diffhunk://#diff-8c25688543c4f824641cbe72c7430468d4575bb6e5b947773073c7e443a5bf8eL121-R136) [[2]](diffhunk://#diff-8c25688543c4f824641cbe72c7430468d4575bb6e5b947773073c7e443a5bf8eL267-R299)

### Styling Enhancements
* Modified the styling of connection handles in both `ActivityNode` and `GeneratorNode` to dynamically adjust opacity based on selection or hover states, improving visual clarity. [[1]](diffhunk://#diff-405baa8efb297ce37bf1b40e681b1a9e44cecb37db8f8b974d96a7d67136cb1fL376-R380) [[2]](diffhunk://#diff-405baa8efb297ce37bf1b40e681b1a9e44cecb37db8f8b974d96a7d67136cb1fL393-R401) [[3]](diffhunk://#diff-8c25688543c4f824641cbe72c7430468d4575bb6e5b947773073c7e443a5bf8eL145-R153) [[4]](diffhunk://#diff-8c25688543c4f824641cbe72c7430468d4575bb6e5b947773073c7e443a5bf8eL186-R206)

### Layout Adjustments
* Adjusted padding and alignment in the `GeneratorNode` content area for better visual consistency. [[1]](diffhunk://#diff-8c25688543c4f824641cbe72c7430468d4575bb6e5b947773073c7e443a5bf8eL70-R70) [[2]](diffhunk://#diff-8c25688543c4f824641cbe72c7430468d4575bb6e5b947773073c7e443a5bf8eL121-R136)