### PR TITLE
Add Project Export Page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "o2des-studio",
       "version": "0.1.0",
       "dependencies": {
+        "@monaco-editor/react": "^4.7.0",
         "@radix-ui/react-accordion": "^1.2.11",
         "@radix-ui/react-dropdown-menu": "^2.1.7",
         "@radix-ui/react-label": "^2.1.3",
@@ -20,12 +21,15 @@
         "better-react-mathjax": "^2.2.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "json-edit-react": "^1.26.2",
         "lucide-react": "^0.487.0",
         "nanoid": "^5.1.5",
         "next": "15.3.0",
         "next-themes": "^0.4.6",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-json-view": "^1.21.3",
+        "react-resizable-panels": "^3.0.2",
         "reactflow": "^11.11.4",
         "sonner": "^2.0.3",
         "superjson": "^2.2.2",
@@ -54,6 +58,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.27.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.4.tgz",
+      "integrity": "sha512-t3yaEOuGu9NlIZ+hIeGbBjFtZT7j2cb2tg0fuaJKeGotchRjjLfrBA9Kwf8quhpP1EUuxModQg04q/mBwyg8uA==",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -479,6 +491,27 @@
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@monaco-editor/loader": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.5.0.tgz",
+      "integrity": "sha512-hKoGSM+7aAc7eRTRjpqAZucPmoNOC4UUbknb/VNoTkEIkCPhqV8LfbsgM1webRM7S/z21eHEx9Fkwx8Z/C/+Xw==",
+      "dependencies": {
+        "state-local": "^1.0.6"
+      }
+    },
+    "node_modules/@monaco-editor/react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.7.0.tgz",
+      "integrity": "sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA==",
+      "dependencies": {
+        "@monaco-editor/loader": "^1.5.0"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">= 0.25.0 < 1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@next/env": {
@@ -2392,7 +2425,7 @@
       "version": "19.1.1",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.1.tgz",
       "integrity": "sha512-ePapxDL7qrgqSF67s0h9m412d9DbXyC1n59O2st+9rjuuamWsZuD2w55rqY12CbzsZ7uVXb5Nw0gEp9Z8MMutQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -2402,7 +2435,7 @@
       "version": "19.1.2",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.2.tgz",
       "integrity": "sha512-XGJkWF41Qq305SKWEILa1O8vzhb3aOo3ogBlSmiqNko/WmRb6QIaweuZCXjKygVDXpzXb5wyxKTSOsmkuqj+Qw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
@@ -2419,6 +2452,16 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
+    },
+    "node_modules/base16": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/base16/-/base16-1.0.0.tgz",
+      "integrity": "sha512-pNdYkNPiJUnEhnfXV56+sQy8+AaPcG3POZAUnwr4EeqCUZFz4u2PePbo3e5Gj4ziYPCWGUZT9RHisvJKnwFuBQ=="
     },
     "node_modules/better-react-mathjax": {
       "version": "2.2.0",
@@ -2563,11 +2606,19 @@
         "url": "https://github.com/sponsors/mesqueeb"
       }
     },
+    "node_modules/cross-fetch": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
+      "integrity": "sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==",
+      "dependencies": {
+        "node-fetch": "^2.7.0"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/d3-color": {
@@ -2713,6 +2764,45 @@
         "node": ">=6"
       }
     },
+    "node_modules/fbemitter": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fbemitter/-/fbemitter-3.0.0.tgz",
+      "integrity": "sha512-KWKaceCwKQU0+HPoop6gn4eOHk50bBv/VxjJtGMfwmJt3D29JpN4H4eisCtIPA+a8GVBam+ldMMpMjJUvpDyHw==",
+      "dependencies": {
+        "fbjs": "^3.0.0"
+      }
+    },
+    "node_modules/fbjs": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-3.0.5.tgz",
+      "integrity": "sha512-ztsSx77JBtkuMrEypfhgc3cI0+0h+svqeie7xHbh1k/IKdcydnvadp/mUaGgjAOXQmQSxsqgaRhS3q9fy+1kxg==",
+      "dependencies": {
+        "cross-fetch": "^3.1.5",
+        "fbjs-css-vars": "^1.0.0",
+        "loose-envify": "^1.0.0",
+        "object-assign": "^4.1.0",
+        "promise": "^7.1.1",
+        "setimmediate": "^1.0.5",
+        "ua-parser-js": "^1.0.35"
+      }
+    },
+    "node_modules/fbjs-css-vars": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz",
+      "integrity": "sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ=="
+    },
+    "node_modules/flux": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/flux/-/flux-4.0.4.tgz",
+      "integrity": "sha512-NCj3XlayA2UsapRpM7va6wU1+9rE5FIL7qoMcmxWHRzbp0yujihMBm9BBHZ1MDIk5h5o2Bl6eGiCe8rYELAmYw==",
+      "dependencies": {
+        "fbemitter": "^3.0.0",
+        "fbjs": "^3.0.1"
+      },
+      "peerDependencies": {
+        "react": "^15.0.2 || ^16.0.0 || ^17.0.0"
+      }
+    },
     "node_modules/get-nonce": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
@@ -2756,6 +2846,23 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "node_modules/json-edit-react": {
+      "version": "1.26.2",
+      "resolved": "https://registry.npmjs.org/json-edit-react/-/json-edit-react-1.26.2.tgz",
+      "integrity": "sha512-/8a8je+Wm5/vgrhPJubhjbOoRPzzjPp8dLom4/DSIcRE1cJlgishGriuc//3o0FI+0VhsPYmAIxkvxNpUU6Ykg==",
+      "dependencies": {
+        "object-property-assigner": "^1.3.5",
+        "object-property-extractor": "^1.0.13"
+      },
+      "peerDependencies": {
+        "react": ">=16.0.0"
       }
     },
     "node_modules/lightningcss": {
@@ -2997,6 +3104,27 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lodash.curry": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.curry/-/lodash.curry-4.1.1.tgz",
+      "integrity": "sha512-/u14pXGviLaweY5JI0IUzgzF2J6Ne8INyzAZjImcryjgkZ+ebruBxy2/JaOOkTqScddcYtakjhSaeemV8lR0tA=="
+    },
+    "node_modules/lodash.flow": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.flow/-/lodash.flow-3.5.0.tgz",
+      "integrity": "sha512-ff3BX/tSioo+XojX4MOsOMhJw0nZoUEF011LX8g8d3gvjVbxd89cCio4BCXronjxcTUIJUoqKEUA+n4CqvvRPw=="
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/lucide-react": {
       "version": "0.487.0",
       "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.487.0.tgz",
@@ -3154,6 +3282,43 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-property-assigner": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/object-property-assigner/-/object-property-assigner-1.3.5.tgz",
+      "integrity": "sha512-DIzHzNSTnpoG8QPQCDNrHa6O3vLMhktK3Igirqpk523UYIVe8JNCKcn5C9WyLQxJc58EGsAIiiEu10gqPrud8w=="
+    },
+    "node_modules/object-property-extractor": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/object-property-extractor/-/object-property-extractor-1.0.13.tgz",
+      "integrity": "sha512-9kgEjTWDhTPuPn7nyof+5mLmCKBPKdU0c7IVpTbOvYKYSdXQ5skH4Pa/8MPbZXeyXBGrqS82JyWecsh6tMxiLw=="
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -3208,6 +3373,19 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/promise": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "dependencies": {
+        "asap": "~2.0.3"
+      }
+    },
+    "node_modules/pure-color": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pure-color/-/pure-color-1.3.0.tgz",
+      "integrity": "sha512-QFADYnsVoBMw1srW7OVKEYjG+MbIa49s54w1MA1EDY6r2r/sTcKKYqRX1f4GYvnXP7eN/Pe9HFcX+hwzmrXRHA=="
+    },
     "node_modules/react": {
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
@@ -3215,6 +3393,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-base16-styling": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/react-base16-styling/-/react-base16-styling-0.6.0.tgz",
+      "integrity": "sha512-yvh/7CArceR/jNATXOKDlvTnPKPmGZz7zsenQ3jUwLzHkNUR0CvY3yGYJbWJ/nnxsL8Sgmt5cO3/SILVuPO6TQ==",
+      "dependencies": {
+        "base16": "^1.0.0",
+        "lodash.curry": "^4.0.1",
+        "lodash.flow": "^3.3.0",
+        "pure-color": "^1.2.0"
       }
     },
     "node_modules/react-dom": {
@@ -3228,6 +3417,26 @@
       "peerDependencies": {
         "react": "^19.1.0"
       }
+    },
+    "node_modules/react-json-view": {
+      "version": "1.21.3",
+      "resolved": "https://registry.npmjs.org/react-json-view/-/react-json-view-1.21.3.tgz",
+      "integrity": "sha512-13p8IREj9/x/Ye4WI/JpjhoIwuzEgUAtgJZNBJckfzJt1qyh24BdTm6UQNGnyTq9dapQdrqvquZTo3dz1X6Cjw==",
+      "dependencies": {
+        "flux": "^4.0.1",
+        "react-base16-styling": "^0.6.0",
+        "react-lifecycles-compat": "^3.0.4",
+        "react-textarea-autosize": "^8.3.2"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^16.3.0 || ^15.5.4",
+        "react-dom": "^17.0.0 || ^16.3.0 || ^15.5.4"
+      }
+    },
+    "node_modules/react-lifecycles-compat": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
     "node_modules/react-remove-scroll": {
       "version": "2.6.3",
@@ -3276,6 +3485,15 @@
         }
       }
     },
+    "node_modules/react-resizable-panels": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/react-resizable-panels/-/react-resizable-panels-3.0.2.tgz",
+      "integrity": "sha512-j4RNII75fnHkLnbsTb5G5YsDvJsSEZrJK2XSF2z0Tc2jIonYlIVir/Yh/5LvcUFCfs1HqrMAoiBFmIrRjC4XnA==",
+      "peerDependencies": {
+        "react": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
+    },
     "node_modules/react-style-singleton": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
@@ -3296,6 +3514,22 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-textarea-autosize": {
+      "version": "8.5.9",
+      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.5.9.tgz",
+      "integrity": "sha512-U1DGlIQN5AwgjTyOEnI1oCcMuEr1pv1qOtklB2l4nyMGbHzWrI0eFsYK0zos2YWqAolJyG0IWJaqWmWj5ETh0A==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "use-composed-ref": "^1.3.0",
+        "use-latest": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/reactflow": {
@@ -3334,6 +3568,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
     },
     "node_modules/sharp": {
       "version": "0.34.1",
@@ -3417,6 +3656,11 @@
         "sre": "bin/sre"
       }
     },
+    "node_modules/state-local": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
+      "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w=="
+    },
     "node_modules/streamsearch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
@@ -3487,6 +3731,11 @@
         "node": ">=6"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -3516,6 +3765,31 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/ua-parser-js": {
+      "version": "1.0.40",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.40.tgz",
+      "integrity": "sha512-z6PJ8Lml+v3ichVojCiB8toQJBuwR42ySM4ezjXIqXK3M0HczmKQ3LF4rhU55PfD99KEEXQG6yb7iOMyvYuHew==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        }
+      ],
+      "bin": {
+        "ua-parser-js": "script/cli.js"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
@@ -3537,6 +3811,48 @@
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-composed-ref": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.4.0.tgz",
+      "integrity": "sha512-djviaxuOOh7wkj0paeO1Q/4wMZ8Zrnag5H6yBvzN7AKKe8beOaED9SF5/ByLqsku8NP4zQqsvM2u3ew/tJK8/w==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-isomorphic-layout-effect": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.2.1.tgz",
+      "integrity": "sha512-tpZZ+EX0gaghDAiFR37hj5MgY6ZN55kLiPkJsKxBMZ6GZdOSPJXiOzPM984oPYZ5AnehYx5WQp1+ME8I/P/pRA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-latest": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/use-latest/-/use-latest-1.3.0.tgz",
+      "integrity": "sha512-mhg3xdm9NaM8q+gLT8KryJPnRFOz1/5XPBhmDEVZK1webPzDjrPk7f/mbpeLqTgB9msytYWANxgALOCJKnLvcQ==",
+      "dependencies": {
+        "use-isomorphic-layout-effect": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -3573,6 +3889,20 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/wicked-good-xpath": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,6 @@
         "next-themes": "^0.4.6",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "react-json-view": "^1.21.3",
         "react-resizable-panels": "^3.0.2",
         "reactflow": "^11.11.4",
         "sonner": "^2.0.3",
@@ -58,14 +57,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@babel/runtime": {
-      "version": "7.27.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.4.tgz",
-      "integrity": "sha512-t3yaEOuGu9NlIZ+hIeGbBjFtZT7j2cb2tg0fuaJKeGotchRjjLfrBA9Kwf8quhpP1EUuxModQg04q/mBwyg8uA==",
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -2425,7 +2416,7 @@
       "version": "19.1.1",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.1.tgz",
       "integrity": "sha512-ePapxDL7qrgqSF67s0h9m412d9DbXyC1n59O2st+9rjuuamWsZuD2w55rqY12CbzsZ7uVXb5Nw0gEp9Z8MMutQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -2435,7 +2426,7 @@
       "version": "19.1.2",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.2.tgz",
       "integrity": "sha512-XGJkWF41Qq305SKWEILa1O8vzhb3aOo3ogBlSmiqNko/WmRb6QIaweuZCXjKygVDXpzXb5wyxKTSOsmkuqj+Qw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
@@ -2452,16 +2443,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/asap": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
-    },
-    "node_modules/base16": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/base16/-/base16-1.0.0.tgz",
-      "integrity": "sha512-pNdYkNPiJUnEhnfXV56+sQy8+AaPcG3POZAUnwr4EeqCUZFz4u2PePbo3e5Gj4ziYPCWGUZT9RHisvJKnwFuBQ=="
     },
     "node_modules/better-react-mathjax": {
       "version": "2.2.0",
@@ -2606,19 +2587,11 @@
         "url": "https://github.com/sponsors/mesqueeb"
       }
     },
-    "node_modules/cross-fetch": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
-      "integrity": "sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==",
-      "dependencies": {
-        "node-fetch": "^2.7.0"
-      }
-    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/d3-color": {
@@ -2764,45 +2737,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/fbemitter": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/fbemitter/-/fbemitter-3.0.0.tgz",
-      "integrity": "sha512-KWKaceCwKQU0+HPoop6gn4eOHk50bBv/VxjJtGMfwmJt3D29JpN4H4eisCtIPA+a8GVBam+ldMMpMjJUvpDyHw==",
-      "dependencies": {
-        "fbjs": "^3.0.0"
-      }
-    },
-    "node_modules/fbjs": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-3.0.5.tgz",
-      "integrity": "sha512-ztsSx77JBtkuMrEypfhgc3cI0+0h+svqeie7xHbh1k/IKdcydnvadp/mUaGgjAOXQmQSxsqgaRhS3q9fy+1kxg==",
-      "dependencies": {
-        "cross-fetch": "^3.1.5",
-        "fbjs-css-vars": "^1.0.0",
-        "loose-envify": "^1.0.0",
-        "object-assign": "^4.1.0",
-        "promise": "^7.1.1",
-        "setimmediate": "^1.0.5",
-        "ua-parser-js": "^1.0.35"
-      }
-    },
-    "node_modules/fbjs-css-vars": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz",
-      "integrity": "sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ=="
-    },
-    "node_modules/flux": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/flux/-/flux-4.0.4.tgz",
-      "integrity": "sha512-NCj3XlayA2UsapRpM7va6wU1+9rE5FIL7qoMcmxWHRzbp0yujihMBm9BBHZ1MDIk5h5o2Bl6eGiCe8rYELAmYw==",
-      "dependencies": {
-        "fbemitter": "^3.0.0",
-        "fbjs": "^3.0.1"
-      },
-      "peerDependencies": {
-        "react": "^15.0.2 || ^16.0.0 || ^17.0.0"
-      }
-    },
     "node_modules/get-nonce": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
@@ -2847,11 +2781,6 @@
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
-    },
-    "node_modules/js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/json-edit-react": {
       "version": "1.26.2",
@@ -3104,27 +3033,6 @@
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/lodash.curry": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.curry/-/lodash.curry-4.1.1.tgz",
-      "integrity": "sha512-/u14pXGviLaweY5JI0IUzgzF2J6Ne8INyzAZjImcryjgkZ+ebruBxy2/JaOOkTqScddcYtakjhSaeemV8lR0tA=="
-    },
-    "node_modules/lodash.flow": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.flow/-/lodash.flow-3.5.0.tgz",
-      "integrity": "sha512-ff3BX/tSioo+XojX4MOsOMhJw0nZoUEF011LX8g8d3gvjVbxd89cCio4BCXronjxcTUIJUoqKEUA+n4CqvvRPw=="
-    },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
-      }
-    },
     "node_modules/lucide-react": {
       "version": "0.487.0",
       "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.487.0.tgz",
@@ -3154,6 +3062,13 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/mj-context-menu/-/mj-context-menu-0.6.1.tgz",
       "integrity": "sha512-7NO5s6n10TIV96d4g2uDpG7ZDpIhMh0QNfGdJw/W47JswFcosz457wqz/b5sAKvl12sxINGFCn80NZHKwxQEXA=="
+    },
+    "node_modules/monaco-editor": {
+      "version": "0.52.2",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
+      "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/nanoid": {
       "version": "5.1.5",
@@ -3282,33 +3197,6 @@
         "node": "^10 || ^12 || >=14"
       }
     },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/object-property-assigner": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/object-property-assigner/-/object-property-assigner-1.3.5.tgz",
@@ -3373,19 +3261,6 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
-    "node_modules/promise": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-      "dependencies": {
-        "asap": "~2.0.3"
-      }
-    },
-    "node_modules/pure-color": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/pure-color/-/pure-color-1.3.0.tgz",
-      "integrity": "sha512-QFADYnsVoBMw1srW7OVKEYjG+MbIa49s54w1MA1EDY6r2r/sTcKKYqRX1f4GYvnXP7eN/Pe9HFcX+hwzmrXRHA=="
-    },
     "node_modules/react": {
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
@@ -3393,17 +3268,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-base16-styling": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/react-base16-styling/-/react-base16-styling-0.6.0.tgz",
-      "integrity": "sha512-yvh/7CArceR/jNATXOKDlvTnPKPmGZz7zsenQ3jUwLzHkNUR0CvY3yGYJbWJ/nnxsL8Sgmt5cO3/SILVuPO6TQ==",
-      "dependencies": {
-        "base16": "^1.0.0",
-        "lodash.curry": "^4.0.1",
-        "lodash.flow": "^3.3.0",
-        "pure-color": "^1.2.0"
       }
     },
     "node_modules/react-dom": {
@@ -3417,26 +3281,6 @@
       "peerDependencies": {
         "react": "^19.1.0"
       }
-    },
-    "node_modules/react-json-view": {
-      "version": "1.21.3",
-      "resolved": "https://registry.npmjs.org/react-json-view/-/react-json-view-1.21.3.tgz",
-      "integrity": "sha512-13p8IREj9/x/Ye4WI/JpjhoIwuzEgUAtgJZNBJckfzJt1qyh24BdTm6UQNGnyTq9dapQdrqvquZTo3dz1X6Cjw==",
-      "dependencies": {
-        "flux": "^4.0.1",
-        "react-base16-styling": "^0.6.0",
-        "react-lifecycles-compat": "^3.0.4",
-        "react-textarea-autosize": "^8.3.2"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^16.3.0 || ^15.5.4",
-        "react-dom": "^17.0.0 || ^16.3.0 || ^15.5.4"
-      }
-    },
-    "node_modules/react-lifecycles-compat": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
     "node_modules/react-remove-scroll": {
       "version": "2.6.3",
@@ -3516,22 +3360,6 @@
         }
       }
     },
-    "node_modules/react-textarea-autosize": {
-      "version": "8.5.9",
-      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.5.9.tgz",
-      "integrity": "sha512-U1DGlIQN5AwgjTyOEnI1oCcMuEr1pv1qOtklB2l4nyMGbHzWrI0eFsYK0zos2YWqAolJyG0IWJaqWmWj5ETh0A==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "use-composed-ref": "^1.3.0",
-        "use-latest": "^1.2.1"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
     "node_modules/reactflow": {
       "version": "11.11.4",
       "resolved": "https://registry.npmjs.org/reactflow/-/reactflow-11.11.4.tgz",
@@ -3568,11 +3396,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/setimmediate": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
     },
     "node_modules/sharp": {
       "version": "0.34.1",
@@ -3731,11 +3554,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -3765,31 +3583,6 @@
         "node": ">=14.17"
       }
     },
-    "node_modules/ua-parser-js": {
-      "version": "1.0.40",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.40.tgz",
-      "integrity": "sha512-z6PJ8Lml+v3ichVojCiB8toQJBuwR42ySM4ezjXIqXK3M0HczmKQ3LF4rhU55PfD99KEEXQG6yb7iOMyvYuHew==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/ua-parser-js"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/faisalman"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/faisalman"
-        }
-      ],
-      "bin": {
-        "ua-parser-js": "script/cli.js"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/undici-types": {
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
@@ -3811,48 +3604,6 @@
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/use-composed-ref": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.4.0.tgz",
-      "integrity": "sha512-djviaxuOOh7wkj0paeO1Q/4wMZ8Zrnag5H6yBvzN7AKKe8beOaED9SF5/ByLqsku8NP4zQqsvM2u3ew/tJK8/w==",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/use-isomorphic-layout-effect": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.2.1.tgz",
-      "integrity": "sha512-tpZZ+EX0gaghDAiFR37hj5MgY6ZN55kLiPkJsKxBMZ6GZdOSPJXiOzPM984oPYZ5AnehYx5WQp1+ME8I/P/pRA==",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/use-latest": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/use-latest/-/use-latest-1.3.0.tgz",
-      "integrity": "sha512-mhg3xdm9NaM8q+gLT8KryJPnRFOz1/5XPBhmDEVZK1webPzDjrPk7f/mbpeLqTgB9msytYWANxgALOCJKnLvcQ==",
-      "dependencies": {
-        "use-isomorphic-layout-effect": "^1.1.1"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -3889,20 +3640,6 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/wicked-good-xpath": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@monaco-editor/react": "^4.7.0",
     "@radix-ui/react-accordion": "^1.2.11",
     "@radix-ui/react-dropdown-menu": "^2.1.7",
     "@radix-ui/react-label": "^2.1.3",
@@ -21,12 +22,15 @@
     "better-react-mathjax": "^2.2.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "json-edit-react": "^1.26.2",
     "lucide-react": "^0.487.0",
     "nanoid": "^5.1.5",
     "next": "15.3.0",
     "next-themes": "^0.4.6",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-json-view": "^1.21.3",
+    "react-resizable-panels": "^3.0.2",
     "reactflow": "^11.11.4",
     "sonner": "^2.0.3",
     "superjson": "^2.2.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "next-themes": "^0.4.6",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-json-view": "^1.21.3",
     "react-resizable-panels": "^3.0.2",
     "reactflow": "^11.11.4",
     "sonner": "^2.0.3",

--- a/src/app/export/page.tsx
+++ b/src/app/export/page.tsx
@@ -1,0 +1,341 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import "reactflow/dist/style.css";
+import Editor from "@monaco-editor/react";
+import {
+    ResizableHandle,
+    ResizablePanel,
+    ResizablePanelGroup,
+} from "@/components/ui/resizable";
+import { Button } from "@/components/ui/button";
+import { ArrowLeft, Download } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { ExportJsonAutosaveService } from "@/services/ExportJsonAutosaveService";
+import { useStore } from "@/store";
+import { ReadOnlyDiagramCanvas } from "@/components/ReadOnlyDiagramCanvas";
+
+interface ExportData {
+    model: {
+        entityRelationships: any[];
+        resources: any[];
+        activities: any[];
+        connections: any[];
+    };
+}
+
+export default function ExportPage() {
+    const router = useRouter();
+    const [isLoading, setIsLoading] = useState(true);
+    const [exportData, setExportData] = useState<ExportData | null>(null);
+    const [diagramData, setDiagramData] = useState<{
+        nodes: any[];
+        edges: any[];
+    } | null>(null);
+    const [isLoadingDiagram, setIsLoadingDiagram] = useState(false);
+
+    const {
+        loadSerializedState,
+        nodes: storeNodes,
+        edges: storeEdges,
+        metadata,
+        updateMetadata,
+    } = useStore();
+
+    const autosaveService = ExportJsonAutosaveService.getInstance();
+
+    const [formattedDate, setFormattedDate] = useState<string>("");
+
+    useEffect(() => {
+        if (isLoadingDiagram) {
+            const timer = setTimeout(() => {
+                setDiagramData({
+                    nodes: storeNodes,
+                    edges: storeEdges,
+                });
+                setIsLoadingDiagram(false);
+                toast.success("Export data loaded successfully");
+                setIsLoading(false);
+            }, 100);
+
+            return () => clearTimeout(timer);
+        }
+    }, [storeNodes, storeEdges, isLoadingDiagram]);
+
+    useEffect(() => {
+        if (metadata?.modified) {
+            try {
+                const date = new Date(metadata.modified);
+                setFormattedDate(
+                    date.toLocaleString(undefined, {
+                        month: "short",
+                        day: "numeric",
+                        hour: "2-digit",
+                        minute: "2-digit",
+                    })
+                );
+            } catch (e) {
+                setFormattedDate("Unknown");
+            }
+        }
+    }, [metadata?.modified]);
+
+    useEffect(() => {
+        const loadData = async () => {
+            try {
+                const exportParam = sessionStorage.getItem("o2des_export_json");
+
+                const serializedDiagramParam = sessionStorage.getItem(
+                    "o2des_diagram_serialized"
+                );
+
+                if (!exportParam) {
+                    console.error(
+                        "Export page: No export data found in session storage"
+                    );
+                    toast.error("No export data available", {
+                        description:
+                            "Please export from the main application first",
+                    });
+                    setIsLoading(false);
+                    return;
+                }
+
+                if (!serializedDiagramParam) {
+                    console.error(
+                        "Export page: No serialized diagram data found in session storage"
+                    );
+                    toast.error("No diagram data available", {
+                        description:
+                            "Please export from the main application first",
+                    });
+                    setIsLoading(false);
+                    return;
+                }
+
+                const parsedExport = JSON.parse(exportParam);
+
+                const autosavedJson = autosaveService.loadSavedJson();
+                if (autosavedJson) {
+                    setExportData(autosavedJson);
+                    toast.success("Loaded autosaved changes", {
+                        description:
+                            "Your previous JSON edits have been restored",
+                    });
+                } else {
+                    setExportData(parsedExport);
+                }
+
+                setIsLoadingDiagram(true);
+                loadSerializedState(serializedDiagramParam);
+            } catch (error) {
+                console.error(
+                    "Export page: Failed to load export data:",
+                    error
+                );
+                toast.error("Failed to load export data");
+                router.push("/");
+                setIsLoading(false);
+            }
+        };
+
+        loadData();
+    }, [router, loadSerializedState]);
+
+    useEffect(() => {
+        return () => {};
+    }, []);
+
+    const handleDownloadExport = () => {
+        if (!exportData) return;
+
+        const blob = new Blob([JSON.stringify(exportData, null, 2)], {
+            type: "application/json",
+        });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = "simulation-export.json";
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+
+        toast.success("Export file downloaded");
+
+        autosaveService.updateOriginalExportData(exportData);
+    };
+
+    const handleBackToEditor = () => {
+        sessionStorage.removeItem("o2des_export_json");
+        sessionStorage.removeItem("o2des_diagram_serialized");
+        autosaveService.clearSavedJson();
+        router.push("/");
+    };
+
+    if (isLoading) {
+        return (
+            <div className="w-screen h-screen flex items-center justify-center bg-background">
+                <div className="text-center">
+                    <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary mx-auto mb-4"></div>
+                    <h2 className="text-xl font-semibold mb-2">
+                        Processing Export
+                    </h2>
+                    <p className="text-muted-foreground">
+                        Converting diagram to simulation format...
+                    </p>
+                </div>
+            </div>
+        );
+    }
+
+    if (!exportData) {
+        return (
+            <div className="w-screen h-screen flex items-center justify-center bg-background">
+                <div className="text-center">
+                    <h1 className="text-2xl font-bold mb-4">No Export Data</h1>
+                    <p className="text-muted-foreground mb-4">
+                        No export data found.
+                    </p>
+                    <Button onClick={handleBackToEditor}>
+                        <ArrowLeft className="mr-2 h-4 w-4" />
+                        Back to Editor
+                    </Button>
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div className="w-screen h-screen flex flex-col overflow-hidden">
+            {/* Header */}
+            <div className="flex items-center justify-between p-4 border-b">
+                <div className="flex items-center space-x-4">
+                    <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={handleBackToEditor}
+                    >
+                        <ArrowLeft className="mr-2 h-4 w-4" />
+                        Back to Editor
+                    </Button>
+                    <h1 className="text-xl font-semibold">
+                        Export to Simulator
+                    </h1>
+                </div>
+                <Button onClick={handleDownloadExport}>
+                    <Download className="mr-2 h-4 w-4" />
+                    Download Export
+                </Button>
+            </div>
+
+            {/* Content */}
+            <div className="flex-1 flex overflow-hidden">
+                <ResizablePanelGroup direction="horizontal" className="h-full">
+                    {/* Diagram Panel */}
+                    <ResizablePanel defaultSize={60} minSize={30}>
+                        <div className="h-full">
+                            <ReadOnlyDiagramCanvas
+                                nodes={diagramData?.nodes || []}
+                                edges={diagramData?.edges || []}
+                            />
+                        </div>
+                    </ResizablePanel>
+
+                    <ResizableHandle withHandle />
+
+                    {/* JSON Editor Panel */}
+                    <ResizablePanel defaultSize={40} minSize={20}>
+                        <div className="h-full flex flex-col">
+                            <div className="p-2 bg-muted/30 border-b flex-shrink-0">
+                                <div className="flex justify-between items-center">
+                                    <h2 className="text-sm font-medium">
+                                        Export JSON
+                                    </h2>
+                                    {formattedDate && (
+                                        <div className="text-xs text-muted-foreground flex items-center">
+                                            <span className="mr-1">
+                                                Last modified:
+                                            </span>
+                                            <span className="font-medium">
+                                                {formattedDate}
+                                            </span>
+                                        </div>
+                                    )}
+                                </div>
+                            </div>
+                            <div className="px-4 py-2 bg-blue-50 border-b border-blue-200 flex-shrink-0">
+                                <div className="flex items-start space-x-2">
+                                    <div className="w-4 h-4 rounded-full bg-blue-500 flex-shrink-0 mt-0.5 flex items-center justify-center">
+                                        <span className="text-white text-xs font-bold">
+                                            !
+                                        </span>
+                                    </div>
+                                    <div className="text-sm text-blue-800">
+                                        <span className="font-medium">
+                                            Reminder:
+                                        </span>{" "}
+                                        Please review and adjust the exported
+                                        JSON if needed before downloading. Check
+                                        that all entities, activities, and
+                                        connections are correctly represented.
+                                    </div>
+                                </div>
+                            </div>
+                            <div className="flex-1 p-4">
+                                <Editor
+                                    height="100%"
+                                    defaultLanguage="json"
+                                    value={JSON.stringify(exportData, null, 2)}
+                                    theme="vs-dark"
+                                    options={{
+                                        minimap: { enabled: false },
+                                        scrollBeyondLastLine: false,
+                                        fontSize: 14,
+                                        wordWrap: "on",
+                                        formatOnPaste: true,
+                                        formatOnType: true,
+                                        autoIndent: "full",
+                                        tabSize: 2,
+                                        insertSpaces: true,
+                                        renderWhitespace: "boundary",
+                                        bracketPairColorization: {
+                                            enabled: true,
+                                        },
+                                        folding: true,
+                                        lineNumbers: "on",
+                                        glyphMargin: false,
+                                        contextmenu: true,
+                                        selectOnLineNumbers: true,
+                                        roundedSelection: false,
+                                        readOnly: false,
+                                        automaticLayout: true,
+                                    }}
+                                    onChange={(value) => {
+                                        if (!value) return;
+
+                                        try {
+                                            const updatedData = JSON.parse(
+                                                value
+                                            ) as ExportData;
+                                            setExportData(updatedData);
+                                            autosaveService.autosaveJson(
+                                                updatedData
+                                            );
+
+                                            updateMetadata({
+                                                modified:
+                                                    new Date().toISOString(),
+                                            });
+                                        } catch (error) {}
+                                    }}
+                                />
+                            </div>
+                        </div>
+                    </ResizablePanel>
+                </ResizablePanelGroup>
+            </div>
+        </div>
+    );
+}

--- a/src/components/ReadOnlyDiagramCanvas.tsx
+++ b/src/components/ReadOnlyDiagramCanvas.tsx
@@ -1,0 +1,117 @@
+import React, { useMemo } from "react";
+import ReactFlow, {
+    Background,
+    Controls,
+    MiniMap,
+    ReactFlowProvider,
+    ConnectionMode,
+    SelectionMode,
+} from "reactflow";
+import { nodeTypes } from "@/components/nodes";
+import { edgeTypes } from "@/components/edges";
+import { BaseNode, BaseEdge } from "@/types/base";
+import { GRID_SIZE } from "@/lib/utils/math";
+import "reactflow/dist/style.css";
+
+interface ReadOnlyDiagramCanvasProps {
+    nodes: BaseNode[];
+    edges: BaseEdge[];
+    className?: string;
+}
+
+const flowOptions = {
+    nodeTypes,
+    edgeTypes,
+    nodesDraggable: false,
+    nodesConnectable: false,
+    elementsSelectable: false,
+    connectOnClick: false,
+    connectionMode: ConnectionMode.Loose,
+    selectNodesOnDrag: false,
+    selectionOnDrag: false,
+    panOnScroll: true,
+    panOnDrag: [1, 2] as number[],
+    elevateNodesOnSelect: false,
+    elevateEdgesOnSelect: false,
+    defaultViewport: { x: 0, y: 0, zoom: 1 },
+    minZoom: 0.1,
+    maxZoom: 4,
+    snapToGrid: true,
+    zoomOnScroll: true,
+    zoomOnPinch: true,
+    snapGrid: [GRID_SIZE, GRID_SIZE] as [number, number],
+    deleteKeyCode: null,
+    selectionMode: SelectionMode.Partial,
+    connectionRadius: 25,
+    zoomOnDoubleClick: false,
+    edgesFocusable: false,
+    noDragClassName: "nodrag",
+} as const;
+
+function ReadOnlyFlowCanvas({
+    nodes,
+    edges,
+    className,
+}: ReadOnlyDiagramCanvasProps) {
+    const sortedNodes = useMemo(() => {
+        return [...nodes].sort((a, b) => {
+            if (a.type === "moduleFrame" && b.type !== "moduleFrame") {
+                return -1;
+            }
+            if (a.type !== "moduleFrame" && b.type === "moduleFrame") {
+                return 1;
+            }
+            return 0;
+        });
+    }, [nodes]);
+
+    const readOnlyNodes = useMemo(() => {
+        return sortedNodes.map((node) => ({
+            ...node,
+            data: {
+                ...node.data,
+
+                updateNodeData: undefined,
+            },
+        }));
+    }, [sortedNodes]);
+
+    return (
+        <div className={`h-full ${className || ""}`}>
+            <ReactFlow
+                nodes={readOnlyNodes}
+                edges={edges}
+                {...flowOptions}
+                fitView
+                fitViewOptions={{
+                    padding: 0.2,
+                    includeHiddenNodes: false,
+                }}
+            >
+                <Background />
+                <Controls />
+                <MiniMap
+                    nodeStrokeWidth={3}
+                    nodeColor="#374151"
+                    nodeBorderRadius={2}
+                />
+            </ReactFlow>
+        </div>
+    );
+}
+
+export function ReadOnlyDiagramCanvas({
+    nodes,
+    edges,
+    className,
+}: ReadOnlyDiagramCanvasProps) {
+    return (
+        <ReactFlowProvider>
+            <ReadOnlyFlowCanvas
+                nodes={nodes}
+                edges={edges}
+                className={className}
+            />
+        </ReactFlowProvider>
+    );
+}

--- a/src/components/ui/resizable.tsx
+++ b/src/components/ui/resizable.tsx
@@ -1,0 +1,56 @@
+"use client"
+
+import * as React from "react"
+import { GripVerticalIcon } from "lucide-react"
+import * as ResizablePrimitive from "react-resizable-panels"
+
+import { cn } from "@/lib/utils"
+
+function ResizablePanelGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof ResizablePrimitive.PanelGroup>) {
+  return (
+    <ResizablePrimitive.PanelGroup
+      data-slot="resizable-panel-group"
+      className={cn(
+        "flex h-full w-full data-[panel-group-direction=vertical]:flex-col",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function ResizablePanel({
+  ...props
+}: React.ComponentProps<typeof ResizablePrimitive.Panel>) {
+  return <ResizablePrimitive.Panel data-slot="resizable-panel" {...props} />
+}
+
+function ResizableHandle({
+  withHandle,
+  className,
+  ...props
+}: React.ComponentProps<typeof ResizablePrimitive.PanelResizeHandle> & {
+  withHandle?: boolean
+}) {
+  return (
+    <ResizablePrimitive.PanelResizeHandle
+      data-slot="resizable-handle"
+      className={cn(
+        "bg-border focus-visible:ring-ring relative flex w-px items-center justify-center after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:ring-1 focus-visible:ring-offset-1 focus-visible:outline-hidden data-[panel-group-direction=vertical]:h-px data-[panel-group-direction=vertical]:w-full data-[panel-group-direction=vertical]:after:left-0 data-[panel-group-direction=vertical]:after:h-1 data-[panel-group-direction=vertical]:after:w-full data-[panel-group-direction=vertical]:after:translate-x-0 data-[panel-group-direction=vertical]:after:-translate-y-1/2 [&[data-panel-group-direction=vertical]>div]:rotate-90",
+        className
+      )}
+      {...props}
+    >
+      {withHandle && (
+        <div className="bg-border z-10 flex h-4 w-3 items-center justify-center rounded-xs border">
+          <GripVerticalIcon className="size-2.5" />
+        </div>
+      )}
+    </ResizablePrimitive.PanelResizeHandle>
+  )
+}
+
+export { ResizablePanelGroup, ResizablePanel, ResizableHandle }

--- a/src/examples/test-export.js
+++ b/src/examples/test-export.js
@@ -7,52 +7,28 @@ const depotDemoPath = path.join(
 );
 const depotDemo = JSON.parse(fs.readFileSync(depotDemoPath, "utf8"));
 
-console.log("Loaded Depot-Demo.json");
-console.log("Nodes:", depotDemo.json.nodes.length);
-console.log("Edges:", depotDemo.json.edges.length);
-
-console.log("\n=== NODE TYPES ===");
 const nodeTypes = {};
 depotDemo.json.nodes.forEach((node) => {
     nodeTypes[node.type] = (nodeTypes[node.type] || 0) + 1;
 });
-console.log(nodeTypes);
 
-console.log("\n=== GENERATORS ===");
 const generators = depotDemo.json.nodes.filter((n) => n.type === "generator");
-generators.forEach((gen) => console.log(`- ${gen.name} (${gen.id})`));
 
-console.log("\n=== ACTIVITIES WITH RESOURCES ===");
 const activities = depotDemo.json.nodes.filter((n) => n.type === "activity");
-activities.forEach((activity) => {
-    if (activity.data.resources && activity.data.resources.length > 0) {
-        console.log(
-            `- ${activity.name}: [${activity.data.resources.join(", ")}]`
-        );
-    }
-});
 
-console.log("\n=== EDGE CONDITIONS ===");
 depotDemo.json.edges.forEach((edge) => {
     if (edge.data.condition && edge.data.condition !== "True") {
         const source = depotDemo.json.nodes.find((n) => n.id === edge.source);
         const target = depotDemo.json.nodes.find((n) => n.id === edge.target);
-        console.log(
-            `${source?.name} -> ${target?.name}: ${edge.data.condition}`
-        );
     }
 });
 
-console.log("\n=== DEPENDENCY EDGES ===");
 depotDemo.json.edges.forEach((edge) => {
     if (edge.data.isDependency) {
         const source = depotDemo.json.nodes.find((n) => n.id === edge.source);
         const target = depotDemo.json.nodes.find((n) => n.id === edge.target);
-        console.log(`${source?.name} -> ${target?.name} (dependency)`);
     }
 });
-
-console.log("\n=== MANUAL CONVERSION TEST ===");
 
 const resourceSet = new Set();
 activities.forEach((activity) => {
@@ -62,10 +38,6 @@ activities.forEach((activity) => {
         );
     }
 });
-
-console.log("Resources found:", Array.from(resourceSet));
-
-console.log("\n=== GRAPH TRAVERSAL APPROACH ===");
 
 function findReachableActivities(startNodeId, nodes, edges) {
     const visited = new Set();
@@ -101,7 +73,6 @@ function findReachableActivities(startNodeId, nodes, edges) {
 const activityToHandler = new Map();
 
 generators.forEach((generator) => {
-    console.log(`\nDirect connections from generator: ${generator.name}`);
     const directEdges = depotDemo.json.edges.filter(
         (edge) => edge.source === generator.id && !edge.data.isDependency
     );
@@ -111,35 +82,23 @@ generators.forEach((generator) => {
             (n) => n.id === edge.target
         );
         if (targetNode?.type === "activity") {
-            console.log(`    - ${targetNode.name} (direct)`);
             activityToHandler.set(edge.target, generator.name);
         }
     });
 });
 
 generators.forEach((generator) => {
-    console.log(`\nTraversing from generator: ${generator.name}`);
     const reachableActivities = findReachableActivities(
         generator.id,
         depotDemo.json.nodes,
         depotDemo.json.edges
     );
 
-    console.log(`  Found ${reachableActivities.size} reachable activities:`);
     reachableActivities.forEach((activityId) => {
         const activity = depotDemo.json.nodes.find((n) => n.id === activityId);
         if (activity) {
             if (!activityToHandler.has(activityId)) {
-                console.log(`    - ${activity.name} (reachable)`);
                 activityToHandler.set(activityId, generator.name);
-            } else {
-                console.log(
-                    `    - ${
-                        activity.name
-                    } (already assigned to ${activityToHandler.get(
-                        activityId
-                    )})`
-                );
             }
         }
     });
@@ -151,13 +110,6 @@ activities.forEach((activity) => {
     graphTraversalHandlerTypes[activity.name] = handlerType;
 });
 
-console.log("\n=== FINAL HANDLER TYPE MAPPING (Graph Traversal) ===");
-Object.entries(graphTraversalHandlerTypes).forEach(
-    ([activityName, handlerType]) => {
-        console.log(`- ${activityName}: ${handlerType}`);
-    }
-);
-
 const finalGroupedActivities = {};
 Object.entries(graphTraversalHandlerTypes).forEach(
     ([activityName, handlerType]) => {
@@ -168,15 +120,6 @@ Object.entries(graphTraversalHandlerTypes).forEach(
     }
 );
 
-console.log("\n=== ACTIVITIES BY HANDLER TYPE (Final) ===");
-Object.entries(finalGroupedActivities).forEach(
-    ([handlerType, activityNames]) => {
-        console.log(`\n${handlerType} (${activityNames.length} activities):`);
-        activityNames.forEach((name) => console.log(`  - ${name}`));
-    }
-);
-
-console.log("\n=== ENTITY RELATIONSHIPS INFERENCE ===");
 const entityTypes = new Set(["Truck", "Container", "RS(BA)"]);
 
 const containerActivities = finalGroupedActivities["Container"] || [];
@@ -185,11 +128,6 @@ const hasContainerUsingRS = containerActivities.some((activityName) => {
     return activity?.data.resources?.includes("RS (BA)");
 });
 
-if (hasContainerUsingRS) {
-    console.log("Container -> RS(BA) (container uses RS resources)");
-}
-
-console.log("\n=== FLOW DEPENDENCY ANALYSIS ===");
 depotDemo.json.edges.forEach((edge) => {
     if (edge.data.isDependency) return;
 
@@ -199,31 +137,13 @@ depotDemo.json.edges.forEach((edge) => {
     if (sourceNode?.type === "activity" && targetNode?.type === "activity") {
         const sourceHandler = graphTraversalHandlerTypes[sourceNode.name];
         const targetHandler = graphTraversalHandlerTypes[targetNode.name];
-
-        if (sourceHandler && targetHandler && sourceHandler !== targetHandler) {
-            console.log(
-                `${sourceHandler} -> ${targetHandler} (${sourceNode.name} → ${targetNode.name})`
-            );
-        }
     }
 });
 
-console.log("\n=== RESOURCE USAGE ANALYSIS ===");
 Object.entries(finalGroupedActivities).forEach(
     ([handlerType, activityNames]) => {
-        console.log(`\n${handlerType} activities using resources:`);
         activityNames.forEach((activityName) => {
             const activity = activities.find((a) => a.name === activityName);
-            if (
-                activity?.data.resources &&
-                activity.data.resources.length > 0
-            ) {
-                console.log(
-                    `  - ${activityName}: [${activity.data.resources.join(
-                        ", "
-                    )}]`
-                );
-            }
         });
     }
 );

--- a/src/examples/test-export.ts
+++ b/src/examples/test-export.ts
@@ -1,33 +1,14 @@
 import { ProjectExportService } from "../services/ProjectExportService";
 import depotDemo from "../data/sample_data/Depot-Demo.json";
 
-console.log("Converting Depot-Demo.json to structured model...\n");
-
 try {
     const result = ProjectExportService.convertToStructuredModel(depotDemo);
-
-    console.log("=== ENTITY RELATIONSHIPS ===");
-    console.log(JSON.stringify(result.model.entityRelationships, null, 2));
-
-    console.log("\n=== RESOURCES ===");
-    console.log(JSON.stringify(result.model.resources, null, 2));
-
-    console.log("\n=== ACTIVITIES (first 3) ===");
-    console.log(JSON.stringify(result.model.activities.slice(0, 3), null, 2));
-
-    console.log("\n=== CONNECTIONS (first 5) ===");
-    console.log(JSON.stringify(result.model.connections.slice(0, 5), null, 2));
-
-    console.log(`\nTotal Activities: ${result.model.activities.length}`);
-    console.log(`Total Connections: ${result.model.connections.length}`);
 
     const fs = require("fs");
     const path = require("path");
 
     const outputPath = path.join(__dirname, "converted-depot-demo.json");
     fs.writeFileSync(outputPath, JSON.stringify(result, null, 2));
-
-    console.log(`\nFull output written to: ${outputPath}`);
 } catch (error) {
     console.error("Error during conversion:", error);
 }

--- a/src/services/ExportJsonAutosaveService.ts
+++ b/src/services/ExportJsonAutosaveService.ts
@@ -1,0 +1,88 @@
+import { toast } from "sonner";
+
+/**
+ * Service to handle autosaving the export JSON data to session storage
+ */
+export class ExportJsonAutosaveService {
+    private static instance: ExportJsonAutosaveService;
+    private debounceTimeout: NodeJS.Timeout | null = null;
+    private readonly STORAGE_KEY = "o2des_export_json_autosave";
+    private readonly DEBOUNCE_DELAY = 1000;
+
+    private constructor() {}
+
+    public static getInstance(): ExportJsonAutosaveService {
+        if (!ExportJsonAutosaveService.instance) {
+            ExportJsonAutosaveService.instance =
+                new ExportJsonAutosaveService();
+        }
+        return ExportJsonAutosaveService.instance;
+    }
+
+    /**
+     * Save the export JSON data to session storage with debouncing
+     */
+    public autosaveJson(jsonData: any): void {
+        if (this.debounceTimeout) {
+            clearTimeout(this.debounceTimeout);
+        }
+
+        this.debounceTimeout = setTimeout(() => {
+            try {
+                const serializedData = JSON.stringify(jsonData, null, 2);
+                sessionStorage.setItem(this.STORAGE_KEY, serializedData);
+            } catch (error) {
+                console.error("Error autosaving export JSON:", error);
+                toast.error("Failed to autosave JSON changes");
+            }
+        }, this.DEBOUNCE_DELAY);
+    }
+
+    /**
+     * Load the autosaved export JSON data from session storage
+     */
+    public loadSavedJson(): any | null {
+        try {
+            const savedData = sessionStorage.getItem(this.STORAGE_KEY);
+            if (!savedData) return null;
+
+            return JSON.parse(savedData);
+        } catch (error) {
+            console.error("Error loading autosaved export JSON:", error);
+            this.clearSavedJson();
+            return null;
+        }
+    }
+
+    /**
+     * Check if there's autosaved JSON data
+     */
+    public hasSavedJson(): boolean {
+        try {
+            const savedData = sessionStorage.getItem(this.STORAGE_KEY);
+            return savedData !== null && savedData.trim() !== "";
+        } catch (error) {
+            console.error("Error checking for saved JSON:", error);
+            return false;
+        }
+    }
+
+    /**
+     * Clear the autosaved export JSON data from session storage
+     */
+    public clearSavedJson(): void {
+        sessionStorage.removeItem(this.STORAGE_KEY);
+    }
+
+    /**
+     * Update the original export data in session storage
+     */
+    public updateOriginalExportData(jsonData: any): void {
+        try {
+            const serializedData = JSON.stringify(jsonData, null, 2);
+            sessionStorage.setItem("o2des_export_json", serializedData);
+        } catch (error) {
+            console.error("Error updating original export data:", error);
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces a new export functionality for diagram data, allowing users to export structured JSON and diagram information to a simulator. Key changes include updates to dependencies, the addition of export-related components and services, and enhancements to the toolbar for initiating the export process.

### Export Functionality

* **New export page (`src/app/export/page.tsx`)**: Implements the export interface, including a resizable panel for viewing the diagram and editing JSON data, autosave functionality for JSON edits, and download/export capabilities.
* **Toolbar integration (`src/components/Toolbar.tsx`)**: Adds an option to export diagram data to the simulator, serializes the diagram state, and stores it in `sessionStorage`. [[1]](diffhunk://#diff-3a03c9f623d0ce74fa66112517c1fdae4131b35604b15eec18ee28b4344b0f9eR151-R192) [[2]](diffhunk://#diff-3a03c9f623d0ce74fa66112517c1fdae4131b35604b15eec18ee28b4344b0f9eR301-R310)

### Diagram Rendering

* **Read-only diagram canvas (`src/components/ReadOnlyDiagramCanvas.tsx`)**: Creates a ReactFlow-based component for rendering diagrams in a non-editable format, with features like grid snapping, zoom controls, and minimap.

### UI Enhancements

* **Resizable panels (`src/components/ui/resizable.tsx`)**: Introduces reusable resizable panel components for managing layout in the export page.

### Dependency Updates

* **`package.json` updates**: Adds new dependencies for diagram rendering (`@monaco-editor/react`, `react-resizable-panels`, `react-json-view`) and JSON editing. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R12) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R25-R33)