### PR TITLE
Logic checker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ next-env.d.ts
 # claude
 /.claude*
 CLAUDE.md
+
+# kiro
+/.kiro*

--- a/src/components/edges/activitybased/resourceconstrained/RCQEdge.tsx
+++ b/src/components/edges/activitybased/resourceconstrained/RCQEdge.tsx
@@ -608,6 +608,13 @@ const RCQEdge = memo(
             }
         }, [isConditionDragging, handleConditionDrag, handleConditionDragEnd]);
 
+        // Ensure we always have a visible stroke and strokeWidth
+        const edgeStyle = {
+            stroke: "#3b82f6", // Default blue color for RCQ edges
+            strokeWidth: 2,     // Default width
+            ...style,           // Override with provided style
+        };
+
         return (
             <BaseEdgeComponent
                 id={id}
@@ -617,7 +624,7 @@ const RCQEdge = memo(
                 targetY={targetY}
                 sourcePosition={sourcePosition}
                 targetPosition={targetPosition}
-                style={style}
+                style={edgeStyle}
                 data={data}
                 markerEnd={markerEnd}
                 selected={selected}

--- a/src/components/edges/eventbased/EventGraphEdge.tsx
+++ b/src/components/edges/eventbased/EventGraphEdge.tsx
@@ -602,35 +602,38 @@ const EventGraphEdge = memo(
         const hasErrors = validationErrors.length > 0;
 
         const edgeStyle = useMemo(() => {
-            // Ensure we always have a visible stroke and strokeWidth
-            const baseStyle = {
-                stroke: "#6b7280", // Default gray color
-                strokeWidth: 2,     // Default width
-                ...style,           // Override with provided style
-            };
+            const mergedStyle = { ...style };
 
-            if (!hasErrors) {
-                return baseStyle;
+            if (hasErrors) {
+                const width = mergedStyle.strokeWidth;
+                const numericWidth =
+                    typeof width === "number" ? Math.max(width, 3) : width ?? 3;
+
+                return {
+                    ...mergedStyle,
+                    stroke: "#ef4444",
+                    strokeWidth: numericWidth,
+                };
             }
 
-            const width = baseStyle.strokeWidth;
-            const numericWidth =
-                typeof width === "number"
-                    ? Math.max(width, 3)
-                    : width ?? 3;
+            if (selected) {
+                const {
+                    stroke: _stroke,
+                    strokeWidth: _strokeWidth,
+                    ...rest
+                } = mergedStyle;
+                return rest;
+            }
 
             return {
-                ...baseStyle,
-                stroke: "#ef4444",
-                strokeWidth: numericWidth,
+                stroke: mergedStyle.stroke ?? "#6b7280",
+                strokeWidth: mergedStyle.strokeWidth ?? 2,
+                ...mergedStyle,
             };
-        }, [style, hasErrors]);
+        }, [style, hasErrors, selected]);
 
         return (
-            <ErrorTooltip
-                errors={validationErrors}
-                wrapperElement="g"
-            >
+            <ErrorTooltip errors={validationErrors} wrapperElement="g">
                 <BaseEdgeComponent
                     id={id}
                     sourceX={sourceX}
@@ -645,466 +648,488 @@ const EventGraphEdge = memo(
                     selected={selected}
                     onClick={onClick}
                 >
-                {({
-                    edgePath,
-                    labelX,
-                    labelY,
-                    isSimpleMode,
-                    centerX,
-                    centerY,
-                    currentControlPoints,
-                }: {
-                    edgePath: string;
-                    labelX: number;
-                    labelY: number;
-                    isSimpleMode: boolean;
-                    centerX: number;
-                    centerY: number;
-                    currentControlPoints: { x: number; y: number }[];
-                }) => {
-                    pathStringRef.current = edgePath;
-                    const {
-                        conditionPoint,
-                        delayPoint,
-                        paramPoint,
-                        conditionEdgePoint,
-                        delayEdgePoint,
-                        paramEdgePoint,
-                        conditionAngle,
-                        delayAngle,
-                        paramAngle,
-                    } = calculatePositions(
+                    {({
                         edgePath,
-                        currentControlPoints,
+                        labelX,
+                        labelY,
                         isSimpleMode,
                         centerX,
-                        centerY
-                    );
+                        centerY,
+                        currentControlPoints,
+                    }: {
+                        edgePath: string;
+                        labelX: number;
+                        labelY: number;
+                        isSimpleMode: boolean;
+                        centerX: number;
+                        centerY: number;
+                        currentControlPoints: { x: number; y: number }[];
+                    }) => {
+                        pathStringRef.current = edgePath;
+                        const {
+                            conditionPoint,
+                            delayPoint,
+                            paramPoint,
+                            conditionEdgePoint,
+                            delayEdgePoint,
+                            paramEdgePoint,
+                            conditionAngle,
+                            delayAngle,
+                            paramAngle,
+                        } = calculatePositions(
+                            edgePath,
+                            currentControlPoints,
+                            isSimpleMode,
+                            centerX,
+                            centerY
+                        );
 
-                    const liveCondition =
-                        isConditionDragging && tempConditionTRef.current != null
-                            ? getPointAndAngleOnPath(
-                                  edgePath,
-                                  tempConditionTRef.current,
-                                  sourceX,
-                                  sourceY,
-                                  targetX,
-                                  targetY
-                              )
-                            : {
-                                  x: conditionPoint.x,
-                                  y: conditionPoint.y,
-                                  angle: conditionAngle,
-                              };
-                    const liveDelay =
-                        isDelayDragging && tempDelayTRef.current != null
-                            ? getPointAndAngleOnPath(
-                                  edgePath,
-                                  tempDelayTRef.current,
-                                  sourceX,
-                                  sourceY,
-                                  targetX,
-                                  targetY
-                              )
-                            : {
-                                  x: delayPoint.x,
-                                  y: delayPoint.y,
-                                  angle: delayAngle,
-                              };
-                    const liveParam =
-                        isParamDragging && tempParamTRef.current != null
-                            ? getPointAndAngleOnPath(
-                                  edgePath,
-                                  tempParamTRef.current,
-                                  sourceX,
-                                  sourceY,
-                                  targetX,
-                                  targetY
-                              )
-                            : {
-                                  x: paramPoint.x,
-                                  y: paramPoint.y,
-                                  angle: paramAngle,
-                              };
+                        const liveCondition =
+                            isConditionDragging &&
+                            tempConditionTRef.current != null
+                                ? getPointAndAngleOnPath(
+                                      edgePath,
+                                      tempConditionTRef.current,
+                                      sourceX,
+                                      sourceY,
+                                      targetX,
+                                      targetY
+                                  )
+                                : {
+                                      x: conditionPoint.x,
+                                      y: conditionPoint.y,
+                                      angle: conditionAngle,
+                                  };
+                        const liveDelay =
+                            isDelayDragging && tempDelayTRef.current != null
+                                ? getPointAndAngleOnPath(
+                                      edgePath,
+                                      tempDelayTRef.current,
+                                      sourceX,
+                                      sourceY,
+                                      targetX,
+                                      targetY
+                                  )
+                                : {
+                                      x: delayPoint.x,
+                                      y: delayPoint.y,
+                                      angle: delayAngle,
+                                  };
+                        const liveParam =
+                            isParamDragging && tempParamTRef.current != null
+                                ? getPointAndAngleOnPath(
+                                      edgePath,
+                                      tempParamTRef.current,
+                                      sourceX,
+                                      sourceY,
+                                      targetX,
+                                      targetY
+                                  )
+                                : {
+                                      x: paramPoint.x,
+                                      y: paramPoint.y,
+                                      angle: paramAngle,
+                                  };
 
-                    anchorRef.current.condition = {
-                        x: liveCondition.x,
-                        y: liveCondition.y,
-                    };
-                    anchorRef.current.delay = {
-                        x: liveDelay.x,
-                        y: liveDelay.y,
-                    };
-                    anchorRef.current.parameter = {
-                        x: liveParam.x,
-                        y: liveParam.y,
-                    };
+                        anchorRef.current.condition = {
+                            x: liveCondition.x,
+                            y: liveCondition.y,
+                        };
+                        anchorRef.current.delay = {
+                            x: liveDelay.x,
+                            y: liveDelay.y,
+                        };
+                        anchorRef.current.parameter = {
+                            x: liveParam.x,
+                            y: liveParam.y,
+                        };
 
-                    const defaultConditionOffset = { x: 0, y: -40 };
-                    const defaultDelayOffset = { x: 0, y: -30 };
-                    const defaultParamOffset = { x: 0, y: -50 };
+                        const defaultConditionOffset = { x: 0, y: -40 };
+                        const defaultDelayOffset = { x: 0, y: -30 };
+                        const defaultParamOffset = { x: 0, y: -50 };
 
-                    const conditionLabelOffset =
-                        isConditionDragging && tempConditionPosition
-                            ? {
-                                  x: tempConditionPosition.x - liveCondition.x,
-                                  y: tempConditionPosition.y - liveCondition.y,
-                              }
-                            : data?.conditionLabelOffset ||
-                              defaultConditionOffset;
+                        const conditionLabelOffset =
+                            isConditionDragging && tempConditionPosition
+                                ? {
+                                      x:
+                                          tempConditionPosition.x -
+                                          liveCondition.x,
+                                      y:
+                                          tempConditionPosition.y -
+                                          liveCondition.y,
+                                  }
+                                : data?.conditionLabelOffset ||
+                                  defaultConditionOffset;
 
-                    const delayLabelOffset =
-                        isDelayDragging && tempDelayPosition
-                            ? {
-                                  x: tempDelayPosition.x - liveDelay.x,
-                                  y: tempDelayPosition.y - liveDelay.y,
-                              }
-                            : data?.delayLabelOffset || defaultDelayOffset;
+                        const delayLabelOffset =
+                            isDelayDragging && tempDelayPosition
+                                ? {
+                                      x: tempDelayPosition.x - liveDelay.x,
+                                      y: tempDelayPosition.y - liveDelay.y,
+                                  }
+                                : data?.delayLabelOffset || defaultDelayOffset;
 
-                    const paramLabelOffset =
-                        isParamDragging && tempParamPosition
-                            ? {
-                                  x: tempParamPosition.x - liveParam.x,
-                                  y: tempParamPosition.y - liveParam.y,
-                              }
-                            : data?.parameterLabelOffset || defaultParamOffset;
+                        const paramLabelOffset =
+                            isParamDragging && tempParamPosition
+                                ? {
+                                      x: tempParamPosition.x - liveParam.x,
+                                      y: tempParamPosition.y - liveParam.y,
+                                  }
+                                : data?.parameterLabelOffset ||
+                                  defaultParamOffset;
 
-                    const conditionLabelX =
-                        liveCondition.x + conditionLabelOffset.x;
-                    const conditionLabelY =
-                        liveCondition.y + conditionLabelOffset.y;
-                    const delayLabelX = liveDelay.x + delayLabelOffset.x;
-                    const delayLabelY = liveDelay.y + delayLabelOffset.y;
-                    const paramLabelX = liveParam.x + paramLabelOffset.x;
-                    const paramLabelY = liveParam.y + paramLabelOffset.y;
+                        const conditionLabelX =
+                            liveCondition.x + conditionLabelOffset.x;
+                        const conditionLabelY =
+                            liveCondition.y + conditionLabelOffset.y;
+                        const delayLabelX = liveDelay.x + delayLabelOffset.x;
+                        const delayLabelY = liveDelay.y + delayLabelOffset.y;
+                        const paramLabelX = liveParam.x + paramLabelOffset.x;
+                        const paramLabelY = liveParam.y + paramLabelOffset.y;
 
-                    const allX = [];
-                    const allY = [];
+                        const allX = [];
+                        const allY = [];
 
-                    if (hasCondition) {
-                        allX.push(liveCondition.x, conditionLabelX);
-                        allY.push(liveCondition.y, conditionLabelY);
-                    }
-                    if (hasDelay) {
-                        allX.push(liveDelay.x, delayLabelX);
-                        allY.push(liveDelay.y, delayLabelY);
-                    }
-                    if (hasParameter) {
-                        allX.push(liveParam.x, paramLabelX);
-                        allY.push(liveParam.y, paramLabelY);
-                    }
+                        if (hasCondition) {
+                            allX.push(liveCondition.x, conditionLabelX);
+                            allY.push(liveCondition.y, conditionLabelY);
+                        }
+                        if (hasDelay) {
+                            allX.push(liveDelay.x, delayLabelX);
+                            allY.push(liveDelay.y, delayLabelY);
+                        }
+                        if (hasParameter) {
+                            allX.push(liveParam.x, paramLabelX);
+                            allY.push(liveParam.y, paramLabelY);
+                        }
 
-                    if (allX.length === 0) {
-                        allX.push(sourceX, targetX);
-                        allY.push(sourceY, targetY);
-                    }
+                        if (allX.length === 0) {
+                            allX.push(sourceX, targetX);
+                            allY.push(sourceY, targetY);
+                        }
 
-                    const minX = Math.min(...allX) - 50;
-                    const maxX = Math.max(...allX) + 50;
-                    const minY = Math.min(...allY) - 50;
-                    const maxY = Math.max(...allY) + 50;
+                        const minX = Math.min(...allX) - 50;
+                        const maxX = Math.max(...allX) + 50;
+                        const minY = Math.min(...allY) - 50;
+                        const maxY = Math.max(...allY) + 50;
 
-                    const svgWidth = maxX - minX;
-                    const svgHeight = maxY - minY;
+                        const svgWidth = maxX - minX;
+                        const svgHeight = maxY - minY;
 
-                    return (
-                        <EdgeLabelRenderer>
-                            <svg
-                                style={{
-                                    position: "absolute",
-                                    left: minX,
-                                    top: minY,
-                                    pointerEvents: "none",
-                                    zIndex: 5,
-                                }}
-                                width={svgWidth}
-                                height={svgHeight}
-                                viewBox={`0 0 ${svgWidth} ${svgHeight}`}
-                            >
-                                {hasCondition && (
-                                    <g>
-                                        <path
-                                            d="M -8 0 Q -4 -6 0 0 Q 4 6 8 0"
-                                            stroke={
-                                                selected ? "#3b82f6" : "#6b7280"
-                                            }
-                                            strokeWidth="2"
-                                            fill="none"
-                                            transform={`translate(${
-                                                liveCondition.x - minX
-                                            }, ${
-                                                liveCondition.y - minY
-                                            }) rotate(${liveCondition.angle})`}
-                                        />
+                        return (
+                            <EdgeLabelRenderer>
+                                <svg
+                                    style={{
+                                        position: "absolute",
+                                        left: minX,
+                                        top: minY,
+                                        pointerEvents: "none",
+                                        zIndex: 5,
+                                    }}
+                                    width={svgWidth}
+                                    height={svgHeight}
+                                    viewBox={`0 0 ${svgWidth} ${svgHeight}`}
+                                >
+                                    {hasCondition && (
+                                        <g>
+                                            <path
+                                                d="M -8 0 Q -4 -6 0 0 Q 4 6 8 0"
+                                                stroke={
+                                                    selected
+                                                        ? "#3b82f6"
+                                                        : "#6b7280"
+                                                }
+                                                strokeWidth="2"
+                                                fill="none"
+                                                transform={`translate(${
+                                                    liveCondition.x - minX
+                                                }, ${
+                                                    liveCondition.y - minY
+                                                }) rotate(${
+                                                    liveCondition.angle
+                                                })`}
+                                            />
+                                            <line
+                                                x1={liveCondition.x - minX}
+                                                y1={liveCondition.y - minY}
+                                                x2={conditionLabelX - minX}
+                                                y2={conditionLabelY - minY}
+                                                stroke={
+                                                    selected
+                                                        ? "#3b82f6"
+                                                        : "#6b7280"
+                                                }
+                                                strokeWidth="1"
+                                                strokeDasharray="3,3"
+                                                opacity={0.7}
+                                            />
+                                        </g>
+                                    )}
+
+                                    {hasDelay && (
+                                        <g>
+                                            <g
+                                                transform={`translate(${
+                                                    liveDelay.x - minX
+                                                }, ${
+                                                    liveDelay.y - minY
+                                                }) rotate(${liveDelay.angle})`}
+                                            >
+                                                <line
+                                                    x1={-8}
+                                                    y1={-2}
+                                                    x2={8}
+                                                    y2={-2}
+                                                    stroke={
+                                                        selected
+                                                            ? "#f59e0b"
+                                                            : "#6b7280"
+                                                    }
+                                                    strokeWidth="2"
+                                                />
+                                                <line
+                                                    x1={-8}
+                                                    y1={2}
+                                                    x2={8}
+                                                    y2={2}
+                                                    stroke={
+                                                        selected
+                                                            ? "#f59e0b"
+                                                            : "#6b7280"
+                                                    }
+                                                    strokeWidth="2"
+                                                />
+                                            </g>
+                                            <line
+                                                x1={liveDelay.x - minX}
+                                                y1={liveDelay.y - minY}
+                                                x2={delayLabelX - minX}
+                                                y2={delayLabelY - minY}
+                                                stroke={
+                                                    selected
+                                                        ? "#f59e0b"
+                                                        : "#6b7280"
+                                                }
+                                                strokeWidth="1"
+                                                strokeDasharray="3,3"
+                                                opacity={0.7}
+                                            />
+                                        </g>
+                                    )}
+
+                                    {hasParameter && (
                                         <line
-                                            x1={liveCondition.x - minX}
-                                            y1={liveCondition.y - minY}
-                                            x2={conditionLabelX - minX}
-                                            y2={conditionLabelY - minY}
+                                            x1={liveParam.x - minX}
+                                            y1={liveParam.y - minY}
+                                            x2={paramLabelX - minX}
+                                            y2={paramLabelY - minY}
                                             stroke={
-                                                selected ? "#3b82f6" : "#6b7280"
+                                                selected ? "#10b981" : "#6b7280"
                                             }
                                             strokeWidth="1"
                                             strokeDasharray="3,3"
                                             opacity={0.7}
                                         />
-                                    </g>
+                                    )}
+                                </svg>
+
+                                {hasCondition && (
+                                    <div
+                                        ref={conditionLabelRef}
+                                        style={{
+                                            position: "absolute",
+                                            transform: `translate(-50%, -50%) translate(${
+                                                isConditionDragging &&
+                                                tempConditionPosition
+                                                    ? tempConditionPosition.x
+                                                    : conditionLabelX
+                                            }px,${
+                                                isConditionDragging &&
+                                                tempConditionPosition
+                                                    ? tempConditionPosition.y
+                                                    : conditionLabelY
+                                            }px)`,
+                                            pointerEvents: "all",
+                                            zIndex: 10,
+                                        }}
+                                        className="nodrag nopan"
+                                    >
+                                        <div
+                                            onMouseDown={
+                                                handleConditionDragStart
+                                            }
+                                            className={`edge-label-condition flex justify-center items-center ${
+                                                selected
+                                                    ? "bg-blue-50 dark:bg-blue-900/50"
+                                                    : "bg-white/90 dark:bg-zinc-800/90"
+                                            } px-2 py-1 rounded text-xs ${
+                                                selected
+                                                    ? "shadow-md border border-blue-300 dark:border-blue-600"
+                                                    : "shadow border border-gray-200 dark:border-gray-700"
+                                            } cursor-grab ${
+                                                isConditionDragging
+                                                    ? "cursor-grabbing opacity-70"
+                                                    : ""
+                                            }`}
+                                            style={{
+                                                boxShadow: selected
+                                                    ? "0 2px 4px rgba(59, 130, 246, 0.3)"
+                                                    : "0 1px 3px rgba(0, 0, 0, 0.1)",
+                                                minWidth: "30px",
+                                                backdropFilter: "blur(4px)",
+                                            }}
+                                        >
+                                            {isConditionDragging ? (
+                                                <span>
+                                                    ({data?.condition || "True"}
+                                                    )
+                                                </span>
+                                            ) : (
+                                                <ReactKatex>
+                                                    {`[${
+                                                        data?.condition ||
+                                                        "True"
+                                                    }]`}
+                                                </ReactKatex>
+                                            )}
+                                        </div>
+                                    </div>
                                 )}
 
                                 {hasDelay && (
-                                    <g>
-                                        <g
-                                            transform={`translate(${
-                                                liveDelay.x - minX
-                                            }, ${liveDelay.y - minY}) rotate(${
-                                                liveDelay.angle
-                                            })`}
+                                    <div
+                                        ref={delayLabelRef}
+                                        style={{
+                                            position: "absolute",
+                                            transform: `translate(-50%, -50%) translate(${
+                                                isDelayDragging &&
+                                                tempDelayPosition
+                                                    ? tempDelayPosition.x
+                                                    : delayLabelX
+                                            }px,${
+                                                isDelayDragging &&
+                                                tempDelayPosition
+                                                    ? tempDelayPosition.y
+                                                    : delayLabelY
+                                            }px)`,
+                                            pointerEvents: "all",
+                                            zIndex: 10,
+                                        }}
+                                        className="nodrag nopan"
+                                    >
+                                        <div
+                                            onMouseDown={handleDelayDragStart}
+                                            className={`edge-label-delay flex justify-center items-center ${
+                                                selected
+                                                    ? "bg-orange-50 dark:bg-orange-900/50"
+                                                    : "bg-white/90 dark:bg-zinc-800/90"
+                                            } px-2 py-1 rounded text-xs ${
+                                                selected
+                                                    ? "shadow-md border border-orange-300 dark:border-orange-600"
+                                                    : "shadow border border-gray-200 dark:border-gray-700"
+                                            } cursor-grab ${
+                                                isDelayDragging
+                                                    ? "cursor-grabbing opacity-70"
+                                                    : ""
+                                            }`}
+                                            style={{
+                                                boxShadow: selected
+                                                    ? "0 2px 4px rgba(251, 146, 60, 0.3)"
+                                                    : "0 1px 3px rgba(0, 0, 0, 0.1)",
+                                                minWidth: "30px",
+                                                backdropFilter: "blur(4px)",
+                                            }}
                                         >
-                                            <line
-                                                x1={-8}
-                                                y1={-2}
-                                                x2={8}
-                                                y2={-2}
-                                                stroke={
-                                                    selected
-                                                        ? "#f59e0b"
-                                                        : "#6b7280"
-                                                }
-                                                strokeWidth="2"
-                                            />
-                                            <line
-                                                x1={-8}
-                                                y1={2}
-                                                x2={8}
-                                                y2={2}
-                                                stroke={
-                                                    selected
-                                                        ? "#f59e0b"
-                                                        : "#6b7280"
-                                                }
-                                                strokeWidth="2"
-                                            />
-                                        </g>
-                                        <line
-                                            x1={liveDelay.x - minX}
-                                            y1={liveDelay.y - minY}
-                                            x2={delayLabelX - minX}
-                                            y2={delayLabelY - minY}
-                                            stroke={
-                                                selected ? "#f59e0b" : "#6b7280"
-                                            }
-                                            strokeWidth="1"
-                                            strokeDasharray="3,3"
-                                            opacity={0.7}
-                                        />
-                                    </g>
+                                            {isDelayDragging ? (
+                                                <span>
+                                                    {typeof data.delay ===
+                                                        "string" &&
+                                                    data.delay.trim() !== ""
+                                                        ? `{${data.delay}}`
+                                                        : "{}"}
+                                                </span>
+                                            ) : (
+                                                <ReactKatex>
+                                                    {typeof data?.delay ===
+                                                        "string" &&
+                                                    data.delay.trim() !== ""
+                                                        ? `{${data.delay}}`
+                                                        : "{}"}
+                                                </ReactKatex>
+                                            )}
+                                        </div>
+                                    </div>
                                 )}
 
+                                {/* Parameter Label */}
                                 {hasParameter && (
-                                    <line
-                                        x1={liveParam.x - minX}
-                                        y1={liveParam.y - minY}
-                                        x2={paramLabelX - minX}
-                                        y2={paramLabelY - minY}
-                                        stroke={
-                                            selected ? "#10b981" : "#6b7280"
-                                        }
-                                        strokeWidth="1"
-                                        strokeDasharray="3,3"
-                                        opacity={0.7}
-                                    />
+                                    <div
+                                        ref={paramLabelRef}
+                                        style={{
+                                            position: "absolute",
+                                            transform: `translate(-50%, -50%) translate(${
+                                                isParamDragging &&
+                                                tempParamPosition
+                                                    ? tempParamPosition.x
+                                                    : paramLabelX
+                                            }px,${
+                                                isParamDragging &&
+                                                tempParamPosition
+                                                    ? tempParamPosition.y
+                                                    : paramLabelY
+                                            }px)`,
+                                            pointerEvents: "all",
+                                            zIndex: 10,
+                                        }}
+                                        className="nodrag nopan"
+                                    >
+                                        <div
+                                            onMouseDown={handleParamDragStart}
+                                            className={`edge-label-param flex justify-center items-center ${
+                                                selected
+                                                    ? "bg-green-50 dark:bg-green-900/50"
+                                                    : "bg-white/90 dark:bg-zinc-800/90"
+                                            } px-2 py-1 rounded text-xs ${
+                                                selected
+                                                    ? "shadow-md border border-green-300 dark:border-green-600"
+                                                    : "shadow border border-gray-200 dark:border-gray-700"
+                                            } cursor-grab ${
+                                                isParamDragging
+                                                    ? "cursor-grabbing opacity-70"
+                                                    : ""
+                                            }`}
+                                            style={{
+                                                boxShadow: selected
+                                                    ? "0 2px 4px rgba(16, 185, 129, 0.3)"
+                                                    : "0 1px 3px rgba(0, 0, 0, 0.1)",
+                                                minWidth: "20px",
+                                                backdropFilter: "blur(4px)",
+                                            }}
+                                        >
+                                            {isParamDragging ? (
+                                                <span>
+                                                    {typeof data.parameter ===
+                                                        "string" &&
+                                                    data.parameter.trim() !== ""
+                                                        ? data.parameter
+                                                        : ""}
+                                                </span>
+                                            ) : (
+                                                <ReactKatex>
+                                                    {typeof data.parameter ===
+                                                        "string" &&
+                                                    data.parameter.trim() !== ""
+                                                        ? data.parameter
+                                                        : ""}
+                                                </ReactKatex>
+                                            )}
+                                        </div>
+                                    </div>
                                 )}
-                            </svg>
-
-                            {hasCondition && (
-                                <div
-                                    ref={conditionLabelRef}
-                                    style={{
-                                        position: "absolute",
-                                        transform: `translate(-50%, -50%) translate(${
-                                            isConditionDragging &&
-                                            tempConditionPosition
-                                                ? tempConditionPosition.x
-                                                : conditionLabelX
-                                        }px,${
-                                            isConditionDragging &&
-                                            tempConditionPosition
-                                                ? tempConditionPosition.y
-                                                : conditionLabelY
-                                        }px)`,
-                                        pointerEvents: "all",
-                                        zIndex: 10,
-                                    }}
-                                    className="nodrag nopan"
-                                >
-                                    <div
-                                        onMouseDown={handleConditionDragStart}
-                                        className={`edge-label-condition flex justify-center items-center ${
-                                            selected
-                                                ? "bg-blue-50 dark:bg-blue-900/50"
-                                                : "bg-white/90 dark:bg-zinc-800/90"
-                                        } px-2 py-1 rounded text-xs ${
-                                            selected
-                                                ? "shadow-md border border-blue-300 dark:border-blue-600"
-                                                : "shadow border border-gray-200 dark:border-gray-700"
-                                        } cursor-grab ${
-                                            isConditionDragging
-                                                ? "cursor-grabbing opacity-70"
-                                                : ""
-                                        }`}
-                                        style={{
-                                            boxShadow: selected
-                                                ? "0 2px 4px rgba(59, 130, 246, 0.3)"
-                                                : "0 1px 3px rgba(0, 0, 0, 0.1)",
-                                            minWidth: "30px",
-                                            backdropFilter: "blur(4px)",
-                                        }}
-                                    >
-                                        {isConditionDragging ? (
-                                            <span>
-                                                ({data?.condition || "True"})
-                                            </span>
-                                        ) : (
-                                            <ReactKatex>
-                                                {`[${
-                                                    data?.condition || "True"
-                                                }]`}
-                                            </ReactKatex>
-                                        )}
-                                    </div>
-                                </div>
-                            )}
-
-                            {hasDelay && (
-                                <div
-                                    ref={delayLabelRef}
-                                    style={{
-                                        position: "absolute",
-                                        transform: `translate(-50%, -50%) translate(${
-                                            isDelayDragging && tempDelayPosition
-                                                ? tempDelayPosition.x
-                                                : delayLabelX
-                                        }px,${
-                                            isDelayDragging && tempDelayPosition
-                                                ? tempDelayPosition.y
-                                                : delayLabelY
-                                        }px)`,
-                                        pointerEvents: "all",
-                                        zIndex: 10,
-                                    }}
-                                    className="nodrag nopan"
-                                >
-                                    <div
-                                        onMouseDown={handleDelayDragStart}
-                                        className={`edge-label-delay flex justify-center items-center ${
-                                            selected
-                                                ? "bg-orange-50 dark:bg-orange-900/50"
-                                                : "bg-white/90 dark:bg-zinc-800/90"
-                                        } px-2 py-1 rounded text-xs ${
-                                            selected
-                                                ? "shadow-md border border-orange-300 dark:border-orange-600"
-                                                : "shadow border border-gray-200 dark:border-gray-700"
-                                        } cursor-grab ${
-                                            isDelayDragging
-                                                ? "cursor-grabbing opacity-70"
-                                                : ""
-                                        }`}
-                                        style={{
-                                            boxShadow: selected
-                                                ? "0 2px 4px rgba(251, 146, 60, 0.3)"
-                                                : "0 1px 3px rgba(0, 0, 0, 0.1)",
-                                            minWidth: "30px",
-                                            backdropFilter: "blur(4px)",
-                                        }}
-                                    >
-                                        {isDelayDragging ? (
-                                            <span>
-                                                {typeof data.delay ===
-                                                    "string" &&
-                                                data.delay.trim() !== ""
-                                                    ? `{${data.delay}}`
-                                                    : "{}"}
-                                            </span>
-                                        ) : (
-                                            <ReactKatex>
-                                                {typeof data?.delay ===
-                                                    "string" &&
-                                                data.delay.trim() !== ""
-                                                    ? `{${data.delay}}`
-                                                    : "{}"}
-                                            </ReactKatex>
-                                        )}
-                                    </div>
-                                </div>
-                            )}
-
-                            {/* Parameter Label */}
-                            {hasParameter && (
-                                <div
-                                    ref={paramLabelRef}
-                                    style={{
-                                        position: "absolute",
-                                        transform: `translate(-50%, -50%) translate(${
-                                            isParamDragging && tempParamPosition
-                                                ? tempParamPosition.x
-                                                : paramLabelX
-                                        }px,${
-                                            isParamDragging && tempParamPosition
-                                                ? tempParamPosition.y
-                                                : paramLabelY
-                                        }px)`,
-                                        pointerEvents: "all",
-                                        zIndex: 10,
-                                    }}
-                                    className="nodrag nopan"
-                                >
-                                    <div
-                                        onMouseDown={handleParamDragStart}
-                                        className={`edge-label-param flex justify-center items-center ${
-                                            selected
-                                                ? "bg-green-50 dark:bg-green-900/50"
-                                                : "bg-white/90 dark:bg-zinc-800/90"
-                                        } px-2 py-1 rounded text-xs ${
-                                            selected
-                                                ? "shadow-md border border-green-300 dark:border-green-600"
-                                                : "shadow border border-gray-200 dark:border-gray-700"
-                                        } cursor-grab ${
-                                            isParamDragging
-                                                ? "cursor-grabbing opacity-70"
-                                                : ""
-                                        }`}
-                                        style={{
-                                            boxShadow: selected
-                                                ? "0 2px 4px rgba(16, 185, 129, 0.3)"
-                                                : "0 1px 3px rgba(0, 0, 0, 0.1)",
-                                            minWidth: "20px",
-                                            backdropFilter: "blur(4px)",
-                                        }}
-                                    >
-                                        {isParamDragging ? (
-                                            <span>
-                                                {typeof data.parameter ===
-                                                    "string" &&
-                                                data.parameter.trim() !== ""
-                                                    ? data.parameter
-                                                    : ""}
-                                            </span>
-                                        ) : (
-                                            <ReactKatex>
-                                                {typeof data.parameter ===
-                                                    "string" &&
-                                                data.parameter.trim() !== ""
-                                                    ? data.parameter
-                                                    : ""}
-                                            </ReactKatex>
-                                        )}
-                                    </div>
-                                </div>
-                            )}
-                        </EdgeLabelRenderer>
-                    );
-                }}
-            </BaseEdgeComponent>
+                            </EdgeLabelRenderer>
+                        );
+                    }}
+                </BaseEdgeComponent>
             </ErrorTooltip>
         );
     }

--- a/src/components/edges/eventbased/InitializationEdge.tsx
+++ b/src/components/edges/eventbased/InitializationEdge.tsx
@@ -368,29 +368,34 @@ const InitializationEdge = memo(
         const hasErrors = validationErrors.length > 0;
 
         const edgeStyle = useMemo(() => {
-            // Ensure we always have a visible stroke and strokeWidth
-            const baseStyle = {
-                stroke: "#6b7280", // Default gray color (matches EventGraphEdge)
-                strokeWidth: 2,
-                ...style,
-            };
+            const mergedStyle = { ...style };
 
-            if (!hasErrors) {
-                return baseStyle;
+            if (hasErrors) {
+                const width = mergedStyle.strokeWidth;
+                const numericWidth =
+                    typeof width === "number"
+                        ? Math.max(width, 3)
+                        : width ?? 3;
+
+                return {
+                    ...mergedStyle,
+                    stroke: "#ef4444",
+                    strokeWidth: numericWidth,
+                };
             }
 
-            const width = baseStyle.strokeWidth;
-            const numericWidth =
-                typeof width === "number"
-                    ? Math.max(width, 3)
-                    : width ?? 3;
+            if (selected) {
+                const { stroke: _stroke, strokeWidth: _strokeWidth, ...rest } =
+                    mergedStyle;
+                return rest;
+            }
 
             return {
-                ...baseStyle,
-                stroke: "#ef4444",
-                strokeWidth: numericWidth,
+                stroke: mergedStyle.stroke ?? "#6b7280",
+                strokeWidth: mergedStyle.strokeWidth ?? 2,
+                ...mergedStyle,
             };
-        }, [style, hasErrors]);
+        }, [style, hasErrors, selected]);
 
         return (
             <ErrorTooltip

--- a/src/components/nodes/eventbased/EventNode.tsx
+++ b/src/components/nodes/eventbased/EventNode.tsx
@@ -24,6 +24,7 @@ import {
     getVariantTypographyConfig,
 } from "@/lib/utils/typography";
 import { ResponsiveText } from "@/components/ui/ResponsiveText";
+import { ErrorTooltip } from "@/components/ui/ErrorTooltip";
 
 const commandController = CommandController.getInstance();
 
@@ -80,6 +81,11 @@ const EventNode = memo(
 
         const nodeName = storeNode?.name || "Event Node";
         const storeData = storeNode?.data || {};
+
+        // Get validation errors for this node
+        const validationErrors = useStore((state) =>
+            state.getValidationErrors(id)
+        );
         const rawDimensions = {
             width: storeData?.width || 120,
             height: storeData?.height || 50,
@@ -421,10 +427,15 @@ const EventNode = memo(
 
         const ellipseHandles = getEllipseHandlePositions(nodeWidth, nodeHeight);
 
+        const hasErrors = validationErrors.length > 0;
+
         return (
-            <div
-                ref={nodeRef}
-                className={`relative ${selected ? "shadow-lg" : ""}`}
+            <ErrorTooltip errors={validationErrors}>
+                <div
+                    ref={nodeRef}
+                    className={`relative ${selected ? "shadow-lg" : ""} ${
+                        hasErrors ? "shadow-red-200" : ""
+                    }`}
                 style={{
                     width: `${nodeWidth + 2}px`,
                     height: `${nodeHeight + 2}px`,
@@ -449,9 +460,17 @@ const EventNode = memo(
                         rx={(nodeWidth - 2) / 2}
                         ry={(nodeHeight - 2) / 2}
                         fill="white"
-                        stroke={selected ? "#3b82f6" : "currentColor"}
-                        strokeWidth={2}
-                        className="dark:fill-zinc-800"
+                        stroke={
+                            hasErrors
+                                ? "#ef4444"
+                                : selected
+                                ? "#3b82f6"
+                                : "currentColor"
+                        }
+                        strokeWidth={hasErrors ? 3 : 2}
+                        className={`dark:fill-zinc-800 ${
+                            hasErrors ? "drop-shadow-sm" : ""
+                        }`}
                     />
                 </svg>
 
@@ -686,6 +705,7 @@ const EventNode = memo(
                     </>
                 )}
             </div>
+            </ErrorTooltip>
         );
     },
     (prev, next) => {

--- a/src/components/nodes/eventbased/InitializationNode.tsx
+++ b/src/components/nodes/eventbased/InitializationNode.tsx
@@ -24,6 +24,7 @@ import {
     getVariantTypographyConfig,
 } from "@/lib/utils/typography";
 import { ResponsiveText } from "@/components/ui/ResponsiveText";
+import { ErrorTooltip } from "@/components/ui/ErrorTooltip";
 
 const commandController = CommandController.getInstance();
 
@@ -127,6 +128,11 @@ const InitializationNode = memo(
             state.nodes.find((n: BaseNode) => n.id === id)
         );
         const storeData = (storeNode?.data || {}) as InitializationNodeData;
+
+        // Get validation errors for this node
+        const validationErrors = useStore((state) =>
+            state.getValidationErrors(id)
+        );
 
         const [isEditing, setIsEditing] = useState(false);
         const [editValue, setEditValue] = useState("");
@@ -418,14 +424,21 @@ const InitializationNode = memo(
 
         const nodeName = storeNode?.name || id;
 
+        const hasErrors = validationErrors.length > 0;
+
         return (
-            <div
-                ref={nodeRef}
-                className={`relative border-2 ${
-                    selected
-                        ? "border-blue-500"
-                        : "border-black dark:border-white"
-                } bg-white dark:bg-zinc-800 ${selected ? "shadow-lg" : ""}`}
+            <ErrorTooltip errors={validationErrors}>
+                <div
+                    ref={nodeRef}
+                    className={`relative border-2 ${
+                        hasErrors
+                            ? "border-red-500 ring-2 ring-red-300 ring-opacity-50"
+                            : selected
+                            ? "border-blue-500"
+                            : "border-black dark:border-white"
+                    } bg-white dark:bg-zinc-800 ${selected ? "shadow-lg" : ""} ${
+                        hasErrors ? "shadow-red-200" : ""
+                    }`}
                 style={{
                     width: nodeWidth,
                     height: nodeHeight,
@@ -646,6 +659,7 @@ const InitializationNode = memo(
                     </>
                 )}
             </div>
+            </ErrorTooltip>
         );
     },
     (prev, next) => {

--- a/src/components/ui/ErrorTooltip.tsx
+++ b/src/components/ui/ErrorTooltip.tsx
@@ -1,0 +1,124 @@
+import React, { useState, useRef, useEffect, useCallback } from "react";
+import { createPortal } from "react-dom";
+import { ValidationError } from "@/types/validation";
+
+type TooltipWrapperElement = "div" | "span" | "g";
+
+interface ErrorTooltipProps {
+    children: React.ReactNode;
+    errors: ValidationError[];
+    show?: boolean;
+    className?: string;
+    /**
+     * Controls which element wraps the tooltip trigger. Use "g" when
+     * wrapping SVG content so the DOM namespace stays svg-aware.
+     */
+    wrapperElement?: TooltipWrapperElement;
+}
+
+export const ErrorTooltip: React.FC<ErrorTooltipProps> = ({
+    children,
+    errors,
+    show = true,
+    className = "",
+    wrapperElement = "div",
+}) => {
+    const [isVisible, setIsVisible] = useState(false);
+    const [tooltipPosition, setTooltipPosition] = useState({ x: 0, y: 0 });
+    const hoverTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+    const elementRef = useRef<HTMLElement | SVGElement | null>(null);
+
+    // Don't show tooltip if no errors or show is false
+    const shouldShowTooltip = show && errors.length > 0;
+
+    const handleMouseEnter = (event: React.MouseEvent) => {
+        if (!shouldShowTooltip) return;
+
+        // Clear any existing timeout
+        if (hoverTimeoutRef.current) {
+            clearTimeout(hoverTimeoutRef.current);
+        }
+
+        const rect = event.currentTarget.getBoundingClientRect();
+        setTooltipPosition({
+            x: rect.left + rect.width / 2,
+            y: rect.top - 10,
+        });
+        setIsVisible(true);
+    };
+
+    const handleMouseLeave = () => {
+        if (!shouldShowTooltip) return;
+
+        // Add delay before hiding tooltip
+        hoverTimeoutRef.current = setTimeout(() => {
+            setIsVisible(false);
+        }, 200);
+    };
+
+    // Cleanup timeout on unmount
+    useEffect(() => {
+        return () => {
+            if (hoverTimeoutRef.current) {
+                clearTimeout(hoverTimeoutRef.current);
+            }
+        };
+    }, []);
+
+    const tooltipContent = (
+        <div
+            className="fixed z-50 px-3 py-2 text-sm text-white bg-red-800 rounded shadow-lg pointer-events-none max-w-xs"
+            style={{
+                left: tooltipPosition.x,
+                top: tooltipPosition.y,
+                transform: "translate(-50%, -100%)",
+            }}
+        >
+            {errors.length === 1 ? (
+                <div>{errors[0].message}</div>
+            ) : (
+                <div>
+                    <div className="font-semibold mb-1">
+                        {errors.length} validation errors:
+                    </div>
+                    <ul className="list-disc list-inside space-y-1">
+                        {errors.map((error, index) => (
+                            <li key={index} className="text-xs">
+                                {error.message}
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+            )}
+        </div>
+    );
+
+    const Wrapper = wrapperElement as keyof JSX.IntrinsicElements;
+    const setElementRef = useCallback(
+        (node: HTMLElement | SVGElement | null) => {
+            elementRef.current = node;
+        },
+        []
+    );
+
+    return (
+        <>
+            <Wrapper
+                ref={setElementRef}
+                className={className}
+                onMouseEnter={handleMouseEnter}
+                onMouseLeave={handleMouseLeave}
+            >
+                {children}
+            </Wrapper>
+
+            {/* Portal the tooltip to body to avoid transform clipping */}
+            {shouldShowTooltip &&
+                isVisible &&
+                typeof window !== "undefined" &&
+                createPortal(tooltipContent, document.body)}
+        </>
+    );
+};
+
+export default ErrorTooltip;

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -36,7 +36,19 @@ export function useKeyboardShortcuts({
     const { undo, redo } = useStore();
 
     useEffect(() => {
+        const isEditableElement = (element: EventTarget | null) => {
+            if (!element || !(element instanceof HTMLElement)) return false;
+            if (element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement) {
+                return !element.readOnly && !element.disabled;
+            }
+            return element.isContentEditable;
+        };
+
         const handleKeyDown = (event: KeyboardEvent) => {
+            if (isEditableElement(event.target) || isEditableElement(document.activeElement)) {
+                return;
+            }
+
             const isMac = navigator.platform.toUpperCase().indexOf("MAC") >= 0;
             const modifier = isMac ? event.metaKey : event.ctrlKey;
 

--- a/src/lib/routing/constants.ts
+++ b/src/lib/routing/constants.ts
@@ -1,0 +1,11 @@
+/**
+ * Shared constants for orthogonal edge routing behaviour.
+ */
+
+/**
+ * Pixel tolerance used when aligning nearly collinear segments in orthogonal paths.
+ * Keeping this value consistent across routing and simplification prevents slight
+ * drags (< tolerance) from introducing unintended bends when edges are recalculated.
+ */
+export const ORTHOGONAL_ALIGNMENT_TOLERANCE = 6;
+

--- a/src/lib/routing/pathGeneration.ts
+++ b/src/lib/routing/pathGeneration.ts
@@ -10,8 +10,7 @@ import {
     HandleInfo,
 } from "./types";
 import { calculateRoutingEfficiency } from "./distance";
-
-const ORTHOGONAL_ALIGNMENT_TOLERANCE = 6; // px
+import { ORTHOGONAL_ALIGNMENT_TOLERANCE } from "./constants";
 
 function applyAlignmentTolerance(start: Point, end: Point): {
     start: Point;

--- a/src/lib/utils/edge.ts
+++ b/src/lib/utils/edge.ts
@@ -4,6 +4,7 @@ import {
     calculateDynamicOffset,
     arePointsCollinear,
 } from "./math";
+import { ORTHOGONAL_ALIGNMENT_TOLERANCE } from "../routing/constants";
 
 /**
  * Calculate default control points for a multi-segment edge path
@@ -46,6 +47,8 @@ export function simplifyControlPoints(
 ): { x: number; y: number }[] {
     if (controlPoints.length === 0) return controlPoints;
 
+    const alignmentTolerance = ORTHOGONAL_ALIGNMENT_TOLERANCE;
+
     // Consider the full path including endpoints so we can prune
     // the first/last control points if they are redundant with
     // the source/target (previous implementation always preserved them).
@@ -62,7 +65,14 @@ export function simplifyControlPoints(
         const currentPoint = allPoints[i];
         const nextPoint = allPoints[i + 1];
 
-        if (!arePointsCollinear(prevPoint, currentPoint, nextPoint, 1)) {
+        if (
+            !arePointsCollinear(
+                prevPoint,
+                currentPoint,
+                nextPoint,
+                alignmentTolerance
+            )
+        ) {
             cleaned.push(currentPoint);
             continue;
         }
@@ -78,7 +88,7 @@ export function simplifyControlPoints(
             Math.pow(currentPoint.x - midpoint.x, 2) +
                 Math.pow(currentPoint.y - midpoint.y, 2)
         );
-        if (distanceFromMidpoint > 10) {
+        if (distanceFromMidpoint > alignmentTolerance) {
             cleaned.push(currentPoint);
         }
     }

--- a/src/services/GraphValidationService.ts
+++ b/src/services/GraphValidationService.ts
@@ -1,0 +1,352 @@
+import { BaseNode, BaseEdge } from "../types/base";
+import { ValidationError, ValidationResult } from "../types/validation";
+
+export class GraphValidationService {
+    private static instance: GraphValidationService;
+
+    static getInstance(): GraphValidationService {
+        if (!GraphValidationService.instance) {
+            GraphValidationService.instance = new GraphValidationService();
+        }
+        return GraphValidationService.instance;
+    }
+
+    /**
+     * Parse LaTeX expressions and extract variable names
+     */
+    parseLatexExpression(latex: string): string[] {
+        if (!latex || typeof latex !== 'string') return [];
+
+        // Remove LaTeX commands and math delimiters
+        let cleaned = latex
+            .replace(/\$+/g, '') // Remove $ delimiters
+            .replace(/\\[a-zA-Z]+\{[^}]*\}/g, '') // Remove LaTeX commands with braces
+            .replace(/\\[a-zA-Z]+/g, '') // Remove LaTeX commands
+            .replace(/[{}]/g, '') // Remove remaining braces
+            .replace(/\s+/g, ' ') // Normalize whitespace
+            .trim();
+
+        // Extract variable names (letters followed by optional numbers/subscripts)
+        const variablePattern = /\b[a-zA-Z][a-zA-Z0-9_]*\b/g;
+        const matches = cleaned.match(variablePattern) || [];
+
+        // Filter out common mathematical constants and functions
+        const mathConstants = new Set([
+            'sin', 'cos', 'tan', 'log', 'ln', 'exp', 'sqrt', 'abs',
+            'min', 'max', 'sum', 'prod', 'int', 'pi', 'e', 'inf',
+            'True', 'False', 'true', 'false', 'and', 'or', 'not'
+        ]);
+
+        const variables = matches.filter(match => !mathConstants.has(match));
+        return [...new Set(variables)]; // Remove duplicates
+    }
+
+    /**
+     * Parse initialization declarations (e.g., "q = 0; s = 0")
+     */
+    parseInitializations(initializations: string | string[]): string[] {
+        if (!initializations) return [];
+
+        let initString = '';
+        if (Array.isArray(initializations)) {
+            initString = initializations.join('; ');
+        } else {
+            initString = initializations;
+        }
+
+        // Remove LaTeX delimiters if present
+        initString = initString.replace(/\$+/g, '');
+
+        // Extract variable names from assignments (variable = value)
+        const assignmentPattern = /([a-zA-Z][a-zA-Z0-9_]*)\s*=\s*[^;]*/g;
+        const variables: string[] = [];
+        let match;
+
+        while ((match = assignmentPattern.exec(initString)) !== null) {
+            variables.push(match[1]);
+        }
+
+        return [...new Set(variables)];
+    }
+
+    /**
+     * Parse state update expressions (e.g., "{q++; s--}")
+     */
+    parseStateUpdate(stateUpdate: string): string[] {
+        if (!stateUpdate || typeof stateUpdate !== 'string') return [];
+
+        // Remove braces and LaTeX delimiters
+        let cleaned = stateUpdate
+            .replace(/[{}$]/g, '')
+            .trim();
+
+        // Extract variables from operations like q++, s--, q = q + 1, etc.
+        const variables: string[] = [];
+
+        // Match increment/decrement operations
+        const incDecPattern = /([a-zA-Z][a-zA-Z0-9_]*)\s*(\+\+|--)/g;
+        let match;
+        while ((match = incDecPattern.exec(cleaned)) !== null) {
+            variables.push(match[1]);
+        }
+
+        // Match assignment operations
+        const assignmentPattern = /([a-zA-Z][a-zA-Z0-9_]*)\s*=/g;
+        while ((match = assignmentPattern.exec(cleaned)) !== null) {
+            variables.push(match[1]);
+        }
+
+        // Extract any remaining variable references
+        const additionalVars = this.parseLatexExpression(cleaned);
+        variables.push(...additionalVars);
+
+        return [...new Set(variables)];
+    }
+
+    /**
+     * Find the initialization node in the model
+     */
+    findInitializationNode(nodes: BaseNode[]): BaseNode | null {
+        return nodes.find(node => node.type === 'initialization') || null;
+    }
+
+    /**
+     * Get all declared variables from initialization nodes
+     */
+    getDeclaredVariables(nodes: BaseNode[]): string[] {
+        const initNode = this.findInitializationNode(nodes);
+        if (!initNode || !initNode.data?.initializations) {
+            return [];
+        }
+
+        return this.parseInitializations(initNode.data.initializations);
+    }
+
+    /**
+     * Validate a single initialization node
+     */
+    validateInitializationNode(node: BaseNode, allNodes: BaseNode[]): ValidationError[] {
+        const errors: ValidationError[] = [];
+
+        if (node.type !== 'initialization') return errors;
+
+        // When the initialization node has no declarations yet, skip validation.
+        if (!node.data?.initializations ||
+            (Array.isArray(node.data.initializations) && node.data.initializations.length === 0) ||
+            (typeof node.data.initializations === 'string' && node.data.initializations.trim() === '')) {
+            return errors;
+        }
+
+        // Placeholder for future initialization-specific validations.
+
+        return errors;
+    }
+
+    /**
+     * Validate an event node
+     */
+    validateEventNode(node: BaseNode, declaredVariables: string[]): ValidationError[] {
+        const errors: ValidationError[] = [];
+
+        if (node.type !== 'event') return errors;
+
+        if (declaredVariables.length === 0) {
+            return errors;
+        }
+
+        // Validate state updates
+        if (node.data?.stateUpdate) {
+            const usedVariables = this.parseStateUpdate(node.data.stateUpdate);
+            const undeclaredVars = usedVariables.filter(v => !declaredVariables.includes(v));
+
+            if (undeclaredVars.length > 0) {
+                errors.push({
+                    elementId: node.id,
+                    elementType: 'node',
+                    errorType: 'undeclared_variable',
+                    message: `State update references undeclared variables: ${undeclaredVars.join(', ')}`,
+                    field: 'stateUpdate',
+                    undeclaredVariables: undeclaredVars
+                });
+            }
+        }
+
+        return errors;
+    }
+
+    /**
+     * Validate an initialization edge
+     */
+    validateInitializationEdge(edge: BaseEdge, declaredVariables: string[]): ValidationError[] {
+        const errors: ValidationError[] = [];
+
+        if (edge.type !== 'initialization') return errors;
+
+        if (declaredVariables.length === 0) {
+            return errors;
+        }
+
+        // Validate initial delay
+        if (edge.data?.initialDelay) {
+            const usedVariables = this.parseLatexExpression(edge.data.initialDelay);
+            const undeclaredVars = usedVariables.filter(v => !declaredVariables.includes(v));
+
+            if (undeclaredVars.length > 0) {
+                errors.push({
+                    elementId: edge.id,
+                    elementType: 'edge',
+                    errorType: 'undeclared_variable',
+                    message: `Initial delay references undeclared variables: ${undeclaredVars.join(', ')}`,
+                    field: 'initialDelay',
+                    undeclaredVariables: undeclaredVars
+                });
+            }
+        }
+
+        return errors;
+    }
+
+    /**
+     * Validate an event graph edge
+     */
+    validateEventGraphEdge(edge: BaseEdge, declaredVariables: string[]): ValidationError[] {
+        const errors: ValidationError[] = [];
+
+        if (edge.type !== 'eventGraph') return errors;
+
+        if (declaredVariables.length === 0) {
+            return errors;
+        }
+
+        // Validate condition
+        if (edge.data?.condition && edge.data.condition !== 'True') {
+            const usedVariables = this.parseLatexExpression(edge.data.condition);
+            const undeclaredVars = usedVariables.filter(v => !declaredVariables.includes(v));
+
+            if (undeclaredVars.length > 0) {
+                errors.push({
+                    elementId: edge.id,
+                    elementType: 'edge',
+                    errorType: 'invalid_condition',
+                    message: `Condition references undeclared variables: ${undeclaredVars.join(', ')}`,
+                    field: 'condition',
+                    undeclaredVariables: undeclaredVars
+                });
+            }
+        }
+
+        // Validate delay
+        if (edge.data?.delay) {
+            const usedVariables = this.parseLatexExpression(edge.data.delay);
+            const undeclaredVars = usedVariables.filter(v => !declaredVariables.includes(v));
+
+            if (undeclaredVars.length > 0) {
+                errors.push({
+                    elementId: edge.id,
+                    elementType: 'edge',
+                    errorType: 'undeclared_variable',
+                    message: `Delay references undeclared variables: ${undeclaredVars.join(', ')}`,
+                    field: 'delay',
+                    undeclaredVariables: undeclaredVars
+                });
+            }
+        }
+
+        // Validate parameter
+        if (edge.data?.parameter) {
+            const usedVariables = this.parseLatexExpression(edge.data.parameter);
+            const undeclaredVars = usedVariables.filter(v => !declaredVariables.includes(v));
+
+            if (undeclaredVars.length > 0) {
+                errors.push({
+                    elementId: edge.id,
+                    elementType: 'edge',
+                    errorType: 'undeclared_variable',
+                    message: `Parameter references undeclared variables: ${undeclaredVars.join(', ')}`,
+                    field: 'parameter',
+                    undeclaredVariables: undeclaredVars
+                });
+            }
+        }
+
+        return errors;
+    }
+
+    /**
+     * Validate the entire model
+     */
+    validateModel(nodes: BaseNode[], edges: BaseEdge[]): ValidationResult {
+        const errors: ValidationError[] = [];
+
+        // Check for initialization node presence
+        const initNode = this.findInitializationNode(nodes);
+        if (!initNode) {
+            errors.push({
+                elementId: 'model',
+                elementType: 'node',
+                errorType: 'missing_initialization',
+                message: 'Model must begin with an initialization node that declares all variables'
+            });
+            return { isValid: false, errors };
+        }
+
+        // Get declared variables
+        const declaredVariables = this.getDeclaredVariables(nodes);
+
+        // Validate initialization node
+        errors.push(...this.validateInitializationNode(initNode, nodes));
+
+        // Validate all nodes
+        for (const node of nodes) {
+            if (node.type === 'event') {
+                errors.push(...this.validateEventNode(node, declaredVariables));
+            }
+        }
+
+        // Validate all edges
+        for (const edge of edges) {
+            if (edge.type === 'initialization') {
+                errors.push(...this.validateInitializationEdge(edge, declaredVariables));
+            } else if (edge.type === 'eventGraph') {
+                errors.push(...this.validateEventGraphEdge(edge, declaredVariables));
+            }
+        }
+
+        return {
+            isValid: errors.length === 0,
+            errors
+        };
+    }
+
+    /**
+     * Validate a specific element by ID
+     */
+    validateElement(elementId: string, nodes: BaseNode[], edges: BaseEdge[]): ValidationError[] {
+        const declaredVariables = this.getDeclaredVariables(nodes);
+        const errors: ValidationError[] = [];
+
+        // Check if it's a node
+        const node = nodes.find(n => n.id === elementId);
+        if (node) {
+            if (node.type === 'initialization') {
+                errors.push(...this.validateInitializationNode(node, nodes));
+            } else if (node.type === 'event') {
+                errors.push(...this.validateEventNode(node, declaredVariables));
+            }
+            return errors;
+        }
+
+        // Check if it's an edge
+        const edge = edges.find(e => e.id === elementId);
+        if (edge) {
+            if (edge.type === 'initialization') {
+                errors.push(...this.validateInitializationEdge(edge, declaredVariables));
+            } else if (edge.type === 'eventGraph') {
+                errors.push(...this.validateEventGraphEdge(edge, declaredVariables));
+            }
+            return errors;
+        }
+
+        return errors;
+    }
+}

--- a/src/services/SegmentDragHandler.ts
+++ b/src/services/SegmentDragHandler.ts
@@ -119,6 +119,15 @@ export class SegmentDragHandler {
 
         if (!isConnected) return false;
 
+        const haveConsistentDirection = this.haveSameDirectionalSign(
+            segment1,
+            segment2
+        );
+
+        if (!haveConsistentDirection) {
+            return false;
+        }
+
         if (segment1.direction === "horizontal") {
             return Math.abs(segment1.start.y - segment2.end.y) <= tolerance;
         }
@@ -128,6 +137,41 @@ export class SegmentDragHandler {
         }
 
         return false;
+    }
+
+    private haveSameDirectionalSign(
+        segment1: EdgeSegment,
+        segment2: EdgeSegment
+    ): boolean {
+        if (segment1.direction === "horizontal") {
+            const delta1 = segment1.end.x - segment1.start.x;
+            const delta2 = segment2.end.x - segment2.start.x;
+
+            const sign1 = Math.sign(delta1);
+            const sign2 = Math.sign(delta2);
+
+            if (sign1 === 0 || sign2 === 0) {
+                return true;
+            }
+
+            return sign1 === sign2;
+        }
+
+        if (segment1.direction === "vertical") {
+            const delta1 = segment1.end.y - segment1.start.y;
+            const delta2 = segment2.end.y - segment2.start.y;
+
+            const sign1 = Math.sign(delta1);
+            const sign2 = Math.sign(delta2);
+
+            if (sign1 === 0 || sign2 === 0) {
+                return true;
+            }
+
+            return sign1 === sign2;
+        }
+
+        return true;
     }
 
     /**

--- a/src/services/__tests__/SegmentDragHandler.test.ts
+++ b/src/services/__tests__/SegmentDragHandler.test.ts
@@ -80,6 +80,32 @@ describe("SegmentDragHandler", () => {
             expect(segments[0].start).toEqual(sourcePoint);
             expect(segments[0].end).toEqual(targetPoint);
         });
+
+        it("should not merge opposing horizontal segments during consolidation", () => {
+            const customSource: Point = { x: 0, y: 0 };
+            const customTarget: Point = { x: -100, y: -100 };
+            const controlPoints: Point[] = [
+                { x: 100, y: 0 },
+                { x: -150, y: 0 },
+                { x: -150, y: -100 }
+            ];
+
+            const segments = segmentDragHandler.calculateSegments(
+                controlPoints,
+                customSource,
+                customTarget
+            );
+
+            expect(segments).toHaveLength(4);
+            expect(segments[0].direction).toBe("horizontal");
+            expect(segments[1].direction).toBe("horizontal");
+            expect(segments[2].direction).toBe("vertical");
+            expect(segments[3].direction).toBe("horizontal");
+
+            // Ensure opposing horizontal segments remain distinct
+            expect(segments[0].end.x).toBeGreaterThan(segments[0].start.x);
+            expect(segments[1].end.x).toBeLessThan(segments[1].start.x);
+        });
     });
 
     describe("isNearSegmentMidpoint", () => {

--- a/src/types/validation.ts
+++ b/src/types/validation.ts
@@ -1,0 +1,20 @@
+export interface ValidationError {
+    elementId: string;
+    elementType: 'node' | 'edge';
+    errorType: 'missing_initialization' | 'undeclared_variable' | 'invalid_state_update' | 'invalid_condition';
+    message: string;
+    field?: string;
+    undeclaredVariables?: string[];
+}
+
+export interface ValidationResult {
+    isValid: boolean;
+    errors: ValidationError[];
+}
+
+export interface ModelValidationState {
+    errors: ValidationError[];
+    errorMap: Record<string, ValidationError[]>;
+    lastValidated: string | null;
+    isValidating: boolean;
+}


### PR DESCRIPTION
This pull request introduces improvements to edge rendering and interaction logic, focusing on better visual feedback, error highlighting, and more robust segment drag handling. The changes affect both resource-constrained and event-based edge components, ensuring consistent styling and improved user experience, especially when validation errors are present or during drag operations.

### Edge Styling and Error Feedback

* **Event-based edges now visually highlight validation errors:** The `EventGraphEdge` component uses the global store to fetch validation errors for each edge and displays a red stroke with increased width when errors are present. An `ErrorTooltip` is shown for error details. [[1]](diffhunk://#diff-b5ef52dd3cbf26abcb40e2450f369d99b15778aa05492f0c091e35e4a907ac81R62-R66) [[2]](diffhunk://#diff-b5ef52dd3cbf26abcb40e2450f369d99b15778aa05492f0c091e35e4a907ac81R602-R636) [[3]](diffhunk://#diff-b5ef52dd3cbf26abcb40e2450f369d99b15778aa05492f0c091e35e4a907ac81L604-R645)
* **Consistent default styling for resource-constrained edges:** The `RCQEdge` component always applies a default blue stroke and width, ensuring visibility and allowing overrides via the `style` prop. [[1]](diffhunk://#diff-eec6038ffee1cb595d4bc211b9661b201b48677a11bb454a5cf53308afd787c2R611-R617) [[2]](diffhunk://#diff-eec6038ffee1cb595d4bc211b9661b201b48677a11bb454a5cf53308afd787c2L620-R627)

### Edge Segment Drag Logic Improvements

* **Robust segment selection during drag end:** The segment drag logic in `BaseEdgeComponent` now determines the closest segment index based on drag position and segment direction, improving accuracy and preventing errors when segments change during interaction.
* **Simplified segment drag handling:** Unnecessary checks and logic for first/last segments and terminal connections have been removed, streamlining the drag update process. [[1]](diffhunk://#diff-ab33fd45113a529d7740cf57cf2a5c36c7b64ce9e28f6825b2a7e6e35a0220eeL1345-L1361) [[2]](diffhunk://#diff-ab33fd45113a529d7740cf57cf2a5c36c7b64ce9e28f6825b2a7e6e35a0220eeL1402-L1412) [[3]](diffhunk://#diff-ab33fd45113a529d7740cf57cf2a5c36c7b64ce9e28f6825b2a7e6e35a0220eeL1430-L1437)

### Code Quality and Consistency

* **Code formatting and minor refactors:** Several formatting improvements and minor refactors were made in the event-based edge rendering code for better readability and maintainability. [[1]](diffhunk://#diff-b5ef52dd3cbf26abcb40e2450f369d99b15778aa05492f0c091e35e4a907ac81L647-R689) [[2]](diffhunk://#diff-b5ef52dd3cbf26abcb40e2450f369d99b15778aa05492f0c091e35e4a907ac81L712-R759) [[3]](diffhunk://#diff-b5ef52dd3cbf26abcb40e2450f369d99b15778aa05492f0c091e35e4a907ac81L732-R779) [[4]](diffhunk://#diff-b5ef52dd3cbf26abcb40e2450f369d99b15778aa05492f0c091e35e4a907ac81L791-R860) [[5]](diffhunk://#diff-b5ef52dd3cbf26abcb40e2450f369d99b15778aa05492f0c091e35e4a907ac81L821-R876) [[6]](diffhunk://#diff-b5ef52dd3cbf26abcb40e2450f369d99b15778aa05492f0c091e35e4a907ac81L856-R911) [[7]](diffhunk://#diff-b5ef52dd3cbf26abcb40e2450f369d99b15778aa05492f0c091e35e4a907ac81L903-R960) [[8]](diffhunk://#diff-b5ef52dd3cbf26abcb40e2450f369d99b15778aa05492f0c091e35e4a907ac81L927-R991)

---

**References:** [[1]](diffhunk://#diff-b5ef52dd3cbf26abcb40e2450f369d99b15778aa05492f0c091e35e4a907ac81R62-R66) [[2]](diffhunk://#diff-b5ef52dd3cbf26abcb40e2450f369d99b15778aa05492f0c091e35e4a907ac81R602-R636) [[3]](diffhunk://#diff-b5ef52dd3cbf26abcb40e2450f369d99b15778aa05492f0c091e35e4a907ac81L604-R645) [[4]](diffhunk://#diff-eec6038ffee1cb595d4bc211b9661b201b48677a11bb454a5cf53308afd787c2R611-R617) [[5]](diffhunk://#diff-eec6038ffee1cb595d4bc211b9661b201b48677a11bb454a5cf53308afd787c2L620-R627) [[6]](diffhunk://#diff-ab33fd45113a529d7740cf57cf2a5c36c7b64ce9e28f6825b2a7e6e35a0220eeL1452-R1506) [[7]](diffhunk://#diff-ab33fd45113a529d7740cf57cf2a5c36c7b64ce9e28f6825b2a7e6e35a0220eeL1345-L1361) [[8]](diffhunk://#diff-ab33fd45113a529d7740cf57cf2a5c36c7b64ce9e28f6825b2a7e6e35a0220eeL1402-L1412) [[9]](diffhunk://#diff-ab33fd45113a529d7740cf57cf2a5c36c7b64ce9e28f6825b2a7e6e35a0220eeL1430-L1437) [[10]](diffhunk://#diff-b5ef52dd3cbf26abcb40e2450f369d99b15778aa05492f0c091e35e4a907ac81L647-R689) [[11]](diffhunk://#diff-b5ef52dd3cbf26abcb40e2450f369d99b15778aa05492f0c091e35e4a907ac81L712-R759) [[12]](diffhunk://#diff-b5ef52dd3cbf26abcb40e2450f369d99b15778aa05492f0c091e35e4a907ac81L732-R779) [[13]](diffhunk://#diff-b5ef52dd3cbf26abcb40e2450f369d99b15778aa05492f0c091e35e4a907ac81L791-R860) [[14]](diffhunk://#diff-b5ef52dd3cbf26abcb40e2450f369d99b15778aa05492f0c091e35e4a907ac81L821-R876) [[15]](diffhunk://#diff-b5ef52dd3cbf26abcb40e2450f369d99b15778aa05492f0c091e35e4a907ac81L856-R911) [[16]](diffhunk://#diff-b5ef52dd3cbf26abcb40e2450f369d99b15778aa05492f0c091e35e4a907ac81L903-R960) [[17]](diffhunk://#diff-b5ef52dd3cbf26abcb40e2450f369d99b15778aa05492f0c091e35e4a907ac81L927-R991)